### PR TITLE
Update location of SSI logo in people.html

### DIFF
--- a/web2/cadabra2/source/people.html
+++ b/web2/cadabra2/source/people.html
@@ -41,7 +41,7 @@ inspired by <tt>Abra</tt>.
 <p>
   Cadabra has been, is, or will be supported by the following
   organisations:<br/>
-	 <img src="https://www.software.ac.uk/themes/ssi/ssi_logo_with_name-small2.png"
+	 <img src="https://www.software.ac.uk/themes/ssi/images/ssi_logo_with_name-small2.png"
   alt="SSI logo" />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img height="78"
   src="https://www.dur.ac.uk/images/IAS/redesign2014/InstituteofadvancesstudiesIASDurhamUK.jpg"
   alt="IAS logo" /><br/>


### PR DESCRIPTION
This is to fix the SSI logo not displaying at https://cadabra.science/people.html

The SSI logo seems to have moved (into a new `images` subdirectory):
- old: https://www.software.ac.uk/themes/ssi/ssi_logo_with_name-small2.png
- new: https://www.software.ac.uk/themes/ssi/images/ssi_logo_with_name-small2.png