### PR TITLE
Documentation of Vielbein and InverseVielbein properties

### DIFF
--- a/core/algorithms/eliminate_vielbein.cnb
+++ b/core/algorithms/eliminate_vielbein.cnb
@@ -1,0 +1,26 @@
+{
+	"cells" : 
+	[
+		{
+			"cell_origin" : "client",
+			"cell_type" : "latex",
+			"cells" : 
+			[
+				{
+					"cell_origin" : "client",
+					"cell_type" : "latex_view",
+					"source" : "\\algorithm{eliminate_vielbein}{Eliminates vielbein objects.}\n\nNot implemented yet in \\verb|Cadabra2|."
+				}
+			],
+			"hidden" : true,
+			"source" : "\\algorithm{eliminate_vielbein}{Eliminates vielbein objects.}\n\nNot implemented yet in \\verb|Cadabra2|."
+		},
+		{
+			"cell_origin" : "client",
+			"cell_type" : "input",
+			"source" : ""
+		}
+	],
+	"description" : "Cadabra JSON notebook format",
+	"version" : 1
+}

--- a/core/properties/InverseVielbein.cnb
+++ b/core/properties/InverseVielbein.cnb
@@ -1,0 +1,26 @@
+{
+	"cells" : 
+	[
+		{
+			"cell_origin" : "client",
+			"cell_type" : "latex",
+			"cells" : 
+			[
+				{
+					"cell_origin" : "client",
+					"cell_type" : "latex_view",
+					"source" : "\\property{InverseVeilbein}{}\n\nThe partner of \\verb|Vielbein|. See\nthe \\verb|eliminate_vielbein| command for more information on\ntypical usage patterns."
+				}
+			],
+			"hidden" : true,
+			"source" : "\\property{InverseVeilbein}{}\n\nThe partner of \\verb|Vielbein|. See\nthe \\verb|eliminate_vielbein| command for more information on\ntypical usage patterns."
+		},
+		{
+			"cell_origin" : "client",
+			"cell_type" : "input",
+			"source" : ""
+		}
+	],
+	"description" : "Cadabra JSON notebook format",
+	"version" : 1
+}

--- a/core/properties/Vielbein.cnb
+++ b/core/properties/Vielbein.cnb
@@ -1,0 +1,26 @@
+{
+	"cells" : 
+	[
+		{
+			"cell_origin" : "client",
+			"cell_type" : "latex",
+			"cells" : 
+			[
+				{
+					"cell_origin" : "client",
+					"cell_type" : "latex_view",
+					"source" : "\\property{Vielbein}{Convert indices from one type to another}\n\nIndicates that an object can be used to convert indices from one type\nto another, i.e.~is a vielbein or tetrad. For more information, see\n\\verb|eliminate_vielbein|."
+				}
+			],
+			"hidden" : true,
+			"source" : "\\property{Vielbein}{Convert indices from one type to another}\n\nIndicates that an object can be used to convert indices from one type\nto another, i.e.~is a vielbein or tetrad. For more information, see\n\\verb|eliminate_vielbein|."
+		},
+		{
+			"cell_origin" : "client",
+			"cell_type" : "input",
+			"source" : ""
+		}
+	],
+	"description" : "Cadabra JSON notebook format",
+	"version" : 1
+}


### PR DESCRIPTION
I've noticed that the properties `Vielbein` and `InverseVielbein` were implemented but they are not documented. I'm attaching a patch with the `.cnb` files corresponding to the `.tex` files from **Cadabra1.x**. 

Although the documentation can be improved, it is better to wait until the algorithm `eliminate_vielbein` is implemented.

BTW, Is there a way to refer to other properties and algorithms in `.cnb`?, something equivalent to the `cdbseealgo`.