### PR TITLE
Adding notebook: Cartan structural equations and Bianchi identities

### DIFF
--- a/contrib/structure_equations_and_bianchi.cnb
+++ b/contrib/structure_equations_and_bianchi.cnb
@@ -1,0 +1,331 @@
+{
+	"cell_id" : 8723663301882487515,
+	"cells" : 
+	[
+		{
+			"cell_id" : 1525272859004475730,
+			"cell_origin" : "client",
+			"cell_type" : "latex",
+			"cells" : 
+			[
+				{
+					"cell_id" : 13566077905728163112,
+					"cell_origin" : "client",
+					"cell_type" : "latex_view",
+					"source" : "\\part*{Cartan structural equations and Bianchi identity}\n\n\\author{Oscar Castillo-Felisola}\n\n\\section*{Theoretical background}\n\nLet $M$ be a manifold, and $g$ a (semi)Riemannian metric defined on $M$. Then the line element for the metric $g$ is\n\\begin{equation*}\n  d{s}^2(g) = g_{\\mu\\nu} d{x}^\\mu \\otimes d{x}^\\nu.\n\\end{equation*}\nNonetheless, the information about the metric structure of the manifold can be translate to the languages of frames,\n\\begin{equation*}\n  \\begin{split}\n    d{s}^2(g)\n    &= g_{\\mu\\nu} d{x}^\\mu \\otimes d{x}^\\nu \\\\\n    &= \\eta_{ab} \\; e^{a}_{\\mu}(x) \\, e^{b}_{\\nu}(x) \\; d{x}^\\mu \\otimes d{x}^\\nu \\\\\n    &= \\eta_{ab} \\; e^{a} \\otimes e^{b}.\n  \\end{split}\n\\end{equation*}\nTherefore, the vielbein, $e^{a}$, is the fields equivalent to the metric tensor. \nIn order to complete the structure, one needs information about the transport of \ngeometrical objects lying on bundles based on $M$. That information is encoded on \nthe spin connection, $\\omega^{a}{}_{b}$. Using these quantities one finds  the \ngeneralisation of the structure equations of Cartan,\n\\begin{align}\n  d e^{a} + \\omega^{a}{}_{b} \\wedge e^{b} & = T^{a},\n  \\label{firstSE}\\\\\n  d \\omega^{a}{}_{c} + \\omega^{a}{}_{b} \\wedge \\omega^{b}{}_{c} & = R^{a}{}_{c}\n  \\label{secondSE}.\n\\end{align}\nIn the sense of the previous lesson, the torsion 2-form, $T^{a}$, and the curvature 2-form,\n$R^{a}{}_{c}$, measure the impossibility of endow an Euclidean structure on $M$."
+				}
+			],
+			"hidden" : true,
+			"source" : "\\part*{Cartan structural equations and Bianchi identity}\n\n\\author{Oscar Castillo-Felisola}\n\n\\section*{Theoretical background}\n\nLet $M$ be a manifold, and $g$ a (semi)Riemannian metric defined on $M$. Then the line element for the metric $g$ is\n\\begin{equation*}\n  d{s}^2(g) = g_{\\mu\\nu} d{x}^\\mu \\otimes d{x}^\\nu.\n\\end{equation*}\nNonetheless, the information about the metric structure of the manifold can be translate to the languages of frames,\n\\begin{equation*}\n  \\begin{split}\n    d{s}^2(g)\n    &= g_{\\mu\\nu} d{x}^\\mu \\otimes d{x}^\\nu \\\\\n    &= \\eta_{ab} \\; e^{a}_{\\mu}(x) \\, e^{b}_{\\nu}(x) \\; d{x}^\\mu \\otimes d{x}^\\nu \\\\\n    &= \\eta_{ab} \\; e^{a} \\otimes e^{b}.\n  \\end{split}\n\\end{equation*}\nTherefore, the vielbein, $e^{a}$, is the fields equivalent to the metric tensor. \nIn order to complete the structure, one needs information about the transport of \ngeometrical objects lying on bundles based on $M$. That information is encoded on \nthe spin connection, $\\omega^{a}{}_{b}$. Using these quantities one finds  the \ngeneralisation of the structure equations of Cartan,\n\\begin{align}\n  d e^{a} + \\omega^{a}{}_{b} \\wedge e^{b} & = T^{a},\n  \\label{firstSE}\\\\\n  d \\omega^{a}{}_{c} + \\omega^{a}{}_{b} \\wedge \\omega^{b}{}_{c} & = R^{a}{}_{c}\n  \\label{secondSE}.\n\\end{align}\nIn the sense of the previous lesson, the torsion 2-form, $T^{a}$, and the curvature 2-form,\n$R^{a}{}_{c}$, measure the impossibility of endow an Euclidean structure on $M$."
+		},
+		{
+			"cell_id" : 6636631804659548633,
+			"cell_origin" : "client",
+			"cell_type" : "latex",
+			"cells" : 
+			[
+				{
+					"cell_id" : 696216625188839963,
+					"cell_origin" : "client",
+					"cell_type" : "latex_view",
+					"source" : "\\section*{Manipulation of the structural equations}\n\n\\subsection*{Definitions}"
+				}
+			],
+			"hidden" : true,
+			"source" : "\\section*{Manipulation of the structural equations}\n\n\\subsection*{Definitions}"
+		},
+		{
+			"cell_id" : 13528271774984453456,
+			"cell_origin" : "client",
+			"cell_type" : "input",
+			"cells" : 
+			[
+				{
+					"cell_id" : 9223372036854775813,
+					"cell_origin" : "server",
+					"cell_type" : "latex_view",
+					"source" : "\\begin{dmath*}{}\\text{Attached property DifferentialForm to~}\\left[e^{a},~\\discretionary{}{}{} \\omega^{a}\\,_{b}\\right].\\end{dmath*}"
+				},
+				{
+					"cell_id" : 9223372036854775814,
+					"cell_origin" : "server",
+					"cell_type" : "latex_view",
+					"source" : "\\begin{dmath*}{}\\text{Attached property DifferentialForm to~}\\left[T^{a},~\\discretionary{}{}{} R^{a}\\,_{b}\\right].\\end{dmath*}"
+				}
+			],
+			"source" : "{a,b,c,l,m,n}::Indices.\nd{#}::ExteriorDerivative;.\nd{#}::LaTeXForm(\"{\\rm d}\").\n{e^{a}, \\omega^{a}_{b}}::DifferentialForm(degree=1); \n{T^{a}, R^{a}_{b}}::DifferentialForm(degree=2);"
+		},
+		{
+			"cell_id" : 12238953187398236596,
+			"cell_origin" : "client",
+			"cell_type" : "latex",
+			"cells" : 
+			[
+				{
+					"cell_id" : 3573955577442069632,
+					"cell_origin" : "client",
+					"cell_type" : "latex_view",
+					"source" : "\\subsection*{Cartan structural equations}"
+				}
+			],
+			"hidden" : true,
+			"source" : "\\subsection*{Cartan structural equations}"
+		},
+		{
+			"cell_id" : 17296288306406801707,
+			"cell_origin" : "client",
+			"cell_type" : "input",
+			"cells" : 
+			[
+				{
+					"cell_id" : 9223372036854775816,
+					"cell_origin" : "server",
+					"cell_type" : "latex_view",
+					"cells" : 
+					[
+						{
+							"cell_id" : 9223372036854775817,
+							"cell_origin" : "server",
+							"cell_type" : "input_form",
+							"source" : "d(e^{a}) + \\omega^{a}_{b} ^ e^{b}-T^{a} = 0"
+						}
+					],
+					"source" : "\\begin{dmath*}{}{\\rm d}{e^{a}}+\\omega^{a}\\,_{b}\\wedge e^{b}-T^{a} = 0\\end{dmath*}"
+				}
+			],
+			"source" : "struc1 := d{e^{a}} + \\omega^{a}_{b} ^ e^{b} - T^{a} = 0;"
+		},
+		{
+			"cell_id" : 12676826774600030559,
+			"cell_origin" : "client",
+			"cell_type" : "input",
+			"cells" : 
+			[
+				{
+					"cell_id" : 9223372036854775819,
+					"cell_origin" : "server",
+					"cell_type" : "latex_view",
+					"cells" : 
+					[
+						{
+							"cell_id" : 9223372036854775820,
+							"cell_origin" : "server",
+							"cell_type" : "input_form",
+							"source" : "d(\\omega^{a}_{c}) + \\omega^{a}_{b} ^ \\omega^{b}_{c}-R^{a}_{c} = 0"
+						}
+					],
+					"source" : "\\begin{dmath*}{}{\\rm d}{\\omega^{a}\\,_{c}}+\\omega^{a}\\,_{b}\\wedge \\omega^{b}\\,_{c}-R^{a}\\,_{c} = 0\\end{dmath*}"
+				}
+			],
+			"source" : "struc2 := d{\\omega^{a}_{c}} + \\omega^{a}_{b} ^ \\omega^{b}_{c} - R^{a}_{c} = 0;"
+		},
+		{
+			"cell_id" : 13650837369708637637,
+			"cell_origin" : "client",
+			"cell_type" : "latex",
+			"cells" : 
+			[
+				{
+					"cell_id" : 202950397372684813,
+					"cell_origin" : "client",
+					"cell_type" : "latex_view",
+					"source" : "The bianchi identities are obtained by applying the exterior derivative to the structural\n equations.\n\n\\subsection*{First Bianchi identity}"
+				}
+			],
+			"hidden" : true,
+			"source" : "The bianchi identities are obtained by applying the exterior derivative to the structural\n equations.\n\n\\subsection*{First Bianchi identity}"
+		},
+		{
+			"cell_id" : 10781709412135246056,
+			"cell_origin" : "client",
+			"cell_type" : "input",
+			"cells" : 
+			[
+				{
+					"cell_id" : 9223372036854775822,
+					"cell_origin" : "server",
+					"cell_type" : "latex_view",
+					"cells" : 
+					[
+						{
+							"cell_id" : 9223372036854775823,
+							"cell_origin" : "server",
+							"cell_type" : "input_form",
+							"source" : "d(d(e^{a}) + \\omega^{a}_{b} ^ e^{b}-T^{a}) = 0"
+						}
+					],
+					"source" : "\\begin{dmath*}{}{\\rm d}\\left({\\rm d}{e^{a}}+\\omega^{a}\\,_{b}\\wedge e^{b}-T^{a}\\right) = 0\\end{dmath*}"
+				}
+			],
+			"source" : "Bianchi1 :=  d{ @(struc1) };"
+		},
+		{
+			"cell_id" : 13200781608660800209,
+			"cell_origin" : "client",
+			"cell_type" : "input",
+			"cells" : 
+			[
+				{
+					"cell_id" : 9223372036854775825,
+					"cell_origin" : "server",
+					"cell_type" : "latex_view",
+					"cells" : 
+					[
+						{
+							"cell_id" : 9223372036854775826,
+							"cell_origin" : "server",
+							"cell_type" : "input_form",
+							"source" : "d(\\omega^{a}_{b}) ^ e^{b}-\\omega^{a}_{b} ^ d(e^{b})-d(T^{a}) = 0"
+						}
+					],
+					"source" : "\\begin{dmath*}{}{\\rm d}{\\omega^{a}\\,_{b}}\\wedge e^{b}-\\omega^{a}\\,_{b}\\wedge {\\rm d}{e^{b}}-{\\rm d}{T^{a}} = 0\\end{dmath*}"
+				}
+			],
+			"source" : "distribute(Bianchi1)\nproduct_rule(_);"
+		},
+		{
+			"cell_id" : 5318681466055967294,
+			"cell_origin" : "client",
+			"cell_type" : "input",
+			"cells" : 
+			[
+				{
+					"cell_id" : 9223372036854775828,
+					"cell_origin" : "server",
+					"cell_type" : "latex_view",
+					"cells" : 
+					[
+						{
+							"cell_id" : 9223372036854775829,
+							"cell_origin" : "server",
+							"cell_type" : "input_form",
+							"source" : "d(\\omega^{a}_{b}) ^ e^{b} + \\omega^{a}_{b} ^ \\omega^{b}_{c} ^ e^{c}-\\omega^{a}_{b} ^ T^{b}-d(T^{a}) = 0"
+						}
+					],
+					"source" : "\\begin{dmath*}{}{\\rm d}{\\omega^{a}\\,_{b}}\\wedge e^{b}+\\omega^{a}\\,_{b}\\wedge \\omega^{b}\\,_{c}\\wedge e^{c}-\\omega^{a}\\,_{b}\\wedge T^{b}-{\\rm d}{T^{a}} = 0\\end{dmath*}"
+				}
+			],
+			"source" : "substitute(Bianchi1, $d{e^{a}} -> - \\omega^{a}_{b} ^ e^{b} + T^{a}$)\ndistribute(_);"
+		},
+		{
+			"cell_id" : 3924843063471288484,
+			"cell_origin" : "client",
+			"cell_type" : "input",
+			"cells" : 
+			[
+				{
+					"cell_id" : 9223372036854775831,
+					"cell_origin" : "server",
+					"cell_type" : "latex_view",
+					"cells" : 
+					[
+						{
+							"cell_id" : 9223372036854775832,
+							"cell_origin" : "server",
+							"cell_type" : "input_form",
+							"source" : "R^{a}_{b} ^ e^{b}-\\omega^{a}_{b} ^ T^{b}-d(T^{a}) = 0"
+						}
+					],
+					"source" : "\\begin{dmath*}{}R^{a}\\,_{b}\\wedge e^{b}-\\omega^{a}\\,_{b}\\wedge T^{b}-{\\rm d}{T^{a}} = 0\\end{dmath*}"
+				}
+			],
+			"source" : "substitute(Bianchi1, $d{\\omega^{a}_{b}} -> R^{a}_{b} - \\omega^{a}_{c} ^ \\omega^{c}_{b}$)\ndistribute(_)\nrename_dummies(_);"
+		},
+		{
+			"cell_id" : 3283601467486312560,
+			"cell_origin" : "client",
+			"cell_type" : "latex",
+			"cells" : 
+			[
+				{
+					"cell_id" : 9810454215356752931,
+					"cell_origin" : "client",
+					"cell_type" : "latex_view",
+					"source" : "\\subsection*{Second Bianchi identity}"
+				}
+			],
+			"hidden" : true,
+			"source" : "\\subsection*{Second Bianchi identity}"
+		},
+		{
+			"cell_id" : 10044568257557969795,
+			"cell_origin" : "client",
+			"cell_type" : "input",
+			"cells" : 
+			[
+				{
+					"cell_id" : 9223372036854775834,
+					"cell_origin" : "server",
+					"cell_type" : "latex_view",
+					"cells" : 
+					[
+						{
+							"cell_id" : 9223372036854775835,
+							"cell_origin" : "server",
+							"cell_type" : "input_form",
+							"source" : "d(d(\\omega^{a}_{c}) + \\omega^{a}_{b} ^ \\omega^{b}_{c}-R^{a}_{c}) = 0"
+						}
+					],
+					"source" : "\\begin{dmath*}{}{\\rm d}\\left({\\rm d}{\\omega^{a}\\,_{c}}+\\omega^{a}\\,_{b}\\wedge \\omega^{b}\\,_{c}-R^{a}\\,_{c}\\right) = 0\\end{dmath*}"
+				}
+			],
+			"source" : "Bianchi2 := d{ @(struc2) };"
+		},
+		{
+			"cell_id" : 7450601817332024218,
+			"cell_origin" : "client",
+			"cell_type" : "input",
+			"cells" : 
+			[
+				{
+					"cell_id" : 9223372036854775837,
+					"cell_origin" : "server",
+					"cell_type" : "latex_view",
+					"cells" : 
+					[
+						{
+							"cell_id" : 9223372036854775838,
+							"cell_origin" : "server",
+							"cell_type" : "input_form",
+							"source" : "d(\\omega^{a}_{b}) ^ \\omega^{b}_{c}-\\omega^{a}_{b} ^ d(\\omega^{b}_{c})-d(R^{a}_{c}) = 0"
+						}
+					],
+					"source" : "\\begin{dmath*}{}{\\rm d}{\\omega^{a}\\,_{b}}\\wedge \\omega^{b}\\,_{c}-\\omega^{a}\\,_{b}\\wedge {\\rm d}{\\omega^{b}\\,_{c}}-{\\rm d}{R^{a}\\,_{c}} = 0\\end{dmath*}"
+				}
+			],
+			"source" : "distribute(Bianchi2)\nproduct_rule(_);"
+		},
+		{
+			"cell_id" : 17474571898667354088,
+			"cell_origin" : "client",
+			"cell_type" : "input",
+			"cells" : 
+			[
+				{
+					"cell_id" : 9223372036854775840,
+					"cell_origin" : "server",
+					"cell_type" : "latex_view",
+					"cells" : 
+					[
+						{
+							"cell_id" : 9223372036854775841,
+							"cell_origin" : "server",
+							"cell_type" : "input_form",
+							"source" : "R^{a}_{b} ^ \\omega^{b}_{c}-\\omega^{a}_{b} ^ R^{b}_{c}-d(R^{a}_{c}) = 0"
+						}
+					],
+					"source" : "\\begin{dmath*}{}R^{a}\\,_{b}\\wedge \\omega^{b}\\,_{c}-\\omega^{a}\\,_{b}\\wedge R^{b}\\,_{c}-{\\rm d}{R^{a}\\,_{c}} = 0\\end{dmath*}"
+				}
+			],
+			"source" : "substitute(Bianchi2, $d{\\omega^{a}_{b}} -> R^{a}_{b} - \\omega^{a}_{c} ^ \\omega^{c}_{b}$)\ndistribute(_)\nrename_dummies(_);"
+		},
+		{
+			"cell_id" : 4167877586568113468,
+			"cell_origin" : "client",
+			"cell_type" : "input",
+			"source" : ""
+		}
+	],
+	"description" : "Cadabra JSON notebook format",
+	"version" : 1
+}


### PR DESCRIPTION
A short notebook on the manipulation of the structural equations, using differential forms. Inspired by an example from `exterior.cnb`

-------

**Note:** If a covariant exterior derivative could be defined, say $D$, the Bianchi identities can be written as 
$D T^a = R^a{}_b e^b$ and $D R^a{}_b = 0$. So far, I couldn't write such derivative.