### PR TITLE
Another fix for cyclicity

### DIFF
--- a/core/algorithms/sort_product.cc
+++ b/core/algorithms/sort_product.cc
@@ -142,8 +142,7 @@ Algorithm::result_t sort_product::apply(iterator& st)
 					compare.clear();
 					auto es=compare.equal_subtree(one, two);
 					if(es==Ex_comparator::match_t::no_match_greater || es==Ex_comparator::match_t::match_index_greater) {
-						--candidate;
-						candidate=candidates.erase(candidate);
+						candidate=candidates.erase(candidates.begin(), candidate);
 						one=candidate->at(digit-1);
 						++candidate;
 						}


### PR DESCRIPTION
When an ordering is found to be the best, it wins over all previously tried candidates, not just the most recent one. This oversight becomes apparent when looking at the recent discussion on the Cadabra Q&A forum.