### PR TITLE
Changes to Traceless and AntiSymmetric

### DIFF
--- a/core/Algorithm.cc
+++ b/core/Algorithm.cc
@@ -479,15 +479,17 @@ unsigned int Algorithm::number_of_indices(iterator it)
 	return res;
 	}
 
-std::string Algorithm::set_name_of_indices(iterator it)
+std::string Algorithm::get_index_set_name(iterator it) const
 	{
-	std::string res="";
-	index_iterator indit=begin_index(it);
-	if(indit!=end_index(it)) {
-		const Indices *ind=kernel.properties.get<Indices>(indit, true);
-		if(ind) res=ind->set_name;
+	const Indices *ind=kernel.properties.get<Indices>(it, true);
+	if(ind) {
+		return ind->set_name;
+		// TODO: The logic was once as below, but it is no longer clear to
+		// me why that would ever make sense.
+		//		if(ind->parent_name!="") return ind->parent_name;
+		//		else                     return ind->set_name;
 		}
-	return res;
+	else return " undeclared";
 	}
 
 index_iterator Algorithm::begin_index(iterator it) const

--- a/core/Algorithm.cc
+++ b/core/Algorithm.cc
@@ -479,6 +479,16 @@ unsigned int Algorithm::number_of_indices(iterator it)
 	return res;
 	}
 
+std::string Algorithm::set_name_of_indices(iterator it)
+	{
+	std::string res="";
+	index_iterator indit=begin_index(it);
+	if(indit!=end_index(it)) {
+		const Indices *ind=kernel.properties.get<Indices>(indit, true);
+		if(ind) res=ind->set_name;
+		}
+	return res;
+	}
 
 index_iterator Algorithm::begin_index(iterator it) const
 	{

--- a/core/Algorithm.hh
+++ b/core/Algorithm.hh
@@ -128,6 +128,9 @@ namespace cadabra {
 			// inherited from child nodes).
 			static unsigned int number_of_direct_indices(iterator it);
 
+			// The set to which the first index belongs, defaulting to the empty string.
+			std::string set_name_of_indices(iterator it);
+
 			bool     rename_replacement_dummies(iterator, bool still_inside_algo=false);
 
 

--- a/core/Algorithm.hh
+++ b/core/Algorithm.hh
@@ -128,8 +128,8 @@ namespace cadabra {
 			// inherited from child nodes).
 			static unsigned int number_of_direct_indices(iterator it);
 
-			// The set to which the first index belongs, defaulting to the empty string.
-			std::string set_name_of_indices(iterator it);
+			// The set to which the first index belongs..
+			std::string get_index_set_name(iterator it) const;
 
 			bool     rename_replacement_dummies(iterator, bool still_inside_algo=false);
 

--- a/core/algorithms/canonicalise.cc
+++ b/core/algorithms/canonicalise.cc
@@ -61,7 +61,7 @@ bool canonicalise::remove_traceless_traces(iterator& it)
 				if(ind) {
 					// The indexs need to be in the set for which the object is
 					// traceless (if specified, otherwise accept all).
-					if(ind->set_name==trl->index_set_name || trl->index_set_name=="") {
+					if(trl->index_set_names.find(ind->set_name)!=trl->index_set_names.end() || trl->index_set_names.size()==0) {
 						incremented_now=true;
 						++ihits;
 						}
@@ -90,7 +90,7 @@ bool canonicalise::remove_traceless_traces(iterator& it)
 					indit=begin_index(eform);
 					while(indit!=end_index(eform)) {
 						auto ind=kernel.properties.get<Indices>(indit, true);
-						if(ind->set_name==trl->index_set_name && ind->set_name==trace->index_set_name) ++ehits;
+						if(trl->index_set_names.find(ind->set_name)!=trl->index_set_names.end() && ind->set_name==trace->index_set_name) ++ehits;
 						if(ehits - ihits > 1) {
 							zero(it->multiplier);
 							return true;

--- a/core/algorithms/canonicalise.cc
+++ b/core/algorithms/canonicalise.cc
@@ -140,19 +140,6 @@ Indices::position_t canonicalise::position_type(iterator it) const
 	return Indices::free;
 	}
 
-std::string canonicalise::get_index_set_name(iterator it) const
-	{
-	const Indices *ind=kernel.properties.get<Indices>(it, true);
-	if(ind) {
-		return ind->set_name;
-		// TODO: The logic was once as below, but it is no longer clear to
-		// me why that would ever make sense.
-		//		if(ind->parent_name!="") return ind->parent_name;
-		//		else                     return ind->set_name;
-		}
-	else return " undeclared";
-	}
-
 bool canonicalise::only_one_on_derivative(iterator i1, iterator i2) const
 	{
 	int num=0;

--- a/core/algorithms/canonicalise.hh
+++ b/core/algorithms/canonicalise.hh
@@ -26,7 +26,6 @@ namespace cadabra {
 			bool remove_vanishing_numericals(iterator&);
 			bool only_one_on_derivative(iterator index1, iterator index2) const;
 
-			std::string get_index_set_name(iterator) const;
 			Indices::position_t  position_type(iterator) const;
 			//		void collect_dummy_info(const index_map_t&, const index_position_map_t&,
 			//										std::vector<int>&, std::vector<int>&);

--- a/core/algorithms/epsilon_to_delta.cc
+++ b/core/algorithms/epsilon_to_delta.cc
@@ -22,7 +22,7 @@ bool epsilon_to_delta::can_apply(iterator st)
 	sibling_iterator it=tr.begin(st);
 	while(it!=tr.end(st)) {
 		const EpsilonTensor *eps=kernel.properties.get<EpsilonTensor>(it);
-		if(eps) emap.insert(std::pair<std::string,Ex::iterator>(set_name_of_indices(it),it));
+		if(eps) emap.insert(std::pair<std::string,Ex::iterator>(get_index_set_name(begin_index(it)),it));
 		++it;
 		}
 	signature=1;

--- a/core/algorithms/epsilon_to_delta.cc
+++ b/core/algorithms/epsilon_to_delta.cc
@@ -22,7 +22,7 @@ bool epsilon_to_delta::can_apply(iterator st)
 	sibling_iterator it=tr.begin(st);
 	while(it!=tr.end(st)) {
 		const EpsilonTensor *eps=kernel.properties.get<EpsilonTensor>(it);
-		if(eps) emap.insert(std::pair<std::string,Ex::iterator>(eps->index_set_name,it));
+		if(eps) emap.insert(std::pair<std::string,Ex::iterator>(set_name_of_indices(it),it));
 		++it;
 		}
 	signature=1;

--- a/core/algorithms/join_gamma.cc
+++ b/core/algorithms/join_gamma.cc
@@ -113,11 +113,12 @@ bool join_gamma::can_apply(iterator st)
 		while(fc!=tr.end(st)) {
 			gm1=kernel.properties.get<GammaMatrix>(fc);
 			if(gm1) {
+				std::string target=set_name_of_indices(fc);
 				++fc;
 				if(fc!=tr.end(st)) {
 					gm2=kernel.properties.get<GammaMatrix>(fc);
 					if(gm2) {
-						if(gm1->index_set_name==gm2->index_set_name) {
+						if(target==set_name_of_indices(fc)) {
 							only_expand.clear();
 							// FIXME: handle only expansion into single term
 							//							else if(it->is_rational()) {

--- a/core/algorithms/join_gamma.cc
+++ b/core/algorithms/join_gamma.cc
@@ -113,12 +113,12 @@ bool join_gamma::can_apply(iterator st)
 		while(fc!=tr.end(st)) {
 			gm1=kernel.properties.get<GammaMatrix>(fc);
 			if(gm1) {
-				std::string target=set_name_of_indices(fc);
+				std::string target=get_index_set_name(begin_index(fc));
 				++fc;
 				if(fc!=tr.end(st)) {
 					gm2=kernel.properties.get<GammaMatrix>(fc);
 					if(gm2) {
-						if(target==set_name_of_indices(fc)) {
+						if(target==get_index_set_name(begin_index(fc))) {
 							only_expand.clear();
 							// FIXME: handle only expansion into single term
 							//							else if(it->is_rational()) {

--- a/core/properties/AntiSymmetric.cc
+++ b/core/properties/AntiSymmetric.cc
@@ -9,14 +9,6 @@ std::string AntiSymmetric::name() const
 	return "AntiSymmetric";
 	}
 
-bool AntiSymmetric::parse(Kernel&, keyval_t& keyvals)
-	{
-	keyval_t::const_iterator kv=keyvals.find("indices");
-	if(kv!=keyvals.end())
-		index_set_name=*(kv->second->name);
-	return true;
-	}
-
 unsigned int AntiSymmetric::size(const Properties&, Ex&, Ex::iterator) const
 	{
 	return 1;

--- a/core/properties/AntiSymmetric.hh
+++ b/core/properties/AntiSymmetric.hh
@@ -11,9 +11,6 @@ namespace cadabra {
 		public:
 			virtual ~AntiSymmetric() {};
 			virtual std::string name() const override;
-			virtual bool        parse(Kernel&, keyval_t&) override;
-
-			std::string index_set_name; // refers to Indices::set_name
 
 			virtual unsigned int size(const Properties&, Ex&, Ex::iterator) const override;
 			virtual tab_t        get_tab(const Properties&, Ex&, Ex::iterator, unsigned int) const override;

--- a/core/properties/EpsilonTensor.cc
+++ b/core/properties/EpsilonTensor.cc
@@ -1,10 +1,5 @@
 
-#include "Algorithm.hh"
-#include "Exceptions.hh"
-#include "IndexIterator.hh"
-#include "Kernel.hh"
 #include "properties/EpsilonTensor.hh"
-#include "properties/Integer.hh"
 
 using namespace cadabra;
 
@@ -24,17 +19,3 @@ bool EpsilonTensor::parse(Kernel&, keyval_t& keyvals)
 	return true;
 	}
 
-void EpsilonTensor::validate(const Kernel& kernel, const Ex& pat) const
-	{
-	index_iterator indit=index_iterator::begin(kernel.properties, pat.begin());
-	auto ind1=kernel.properties.get<Indices>(indit, true);
-	auto ind2=kernel.properties.get<Integer>(indit, true);
-	if(ind2) {
-		// This might have to change when index parents become well supported
-		unsigned int dim=to_long(*ind2->difference.begin()->multiplier);
-		if(Algorithm::number_of_indices(kernel.properties, pat.begin())!=dim)
-			throw ConsistencyException("Number of indices does not match the number of values they can take.");
-		}
-	EpsilonTensor *ptr = const_cast<EpsilonTensor*>(this);
-	ptr->index_set_name=ind1->set_name;
-	}

--- a/core/properties/EpsilonTensor.hh
+++ b/core/properties/EpsilonTensor.hh
@@ -12,7 +12,6 @@ namespace cadabra {
 			virtual ~EpsilonTensor() {};
 			virtual std::string name() const override;
 			virtual bool parse(Kernel&, keyval_t&) override;
-			virtual void validate(const Kernel&, const Ex&) const override;
 
 			Ex metric, krdelta;
 		};

--- a/core/properties/GammaMatrix.hh
+++ b/core/properties/GammaMatrix.hh
@@ -11,6 +11,10 @@ namespace cadabra {
 			virtual std::string name() const override;
 			virtual void        latex(std::ostream&) const override;
 			virtual bool        parse(Kernel&, keyval_t& keyvals) override;
+			virtual std::string unnamed_argument() const override
+				{
+				return "explicit";
+				};
 			Ex metric;
 		};
 

--- a/core/properties/Traceless.cc
+++ b/core/properties/Traceless.cc
@@ -10,8 +10,10 @@ std::string Traceless::name() const
 
 bool Traceless::parse(Kernel&, keyval_t& keyvals)
 	{
-	keyval_t::const_iterator kv=keyvals.find("indices");
-	if(kv!=keyvals.end())
-		index_set_name=*(kv->second->name);
+	keyval_t::const_iterator kv=keyvals.begin();
+	while(kv!=keyvals.end()) {
+		if(kv->first=="indices") index_set_names.insert(*kv->second->name);
+		++kv;
+		}
 	return true;
 	}

--- a/core/properties/Traceless.hh
+++ b/core/properties/Traceless.hh
@@ -10,8 +10,12 @@ namespace cadabra {
 			virtual ~Traceless() {};
 			virtual std::string name() const override;
 			virtual bool        parse(Kernel&, keyval_t&) override;
+			virtual std::string unnamed_argument() const override
+				{
+				return "indices";
+				};
 
-			std::string index_set_name; // refers to Indices::set_name
+			std::set<std::string> index_set_names; // refers to Indices::set_name
 		};
 
 	}

--- a/core/properties/WeylTensor.cc
+++ b/core/properties/WeylTensor.cc
@@ -37,7 +37,7 @@ void WeylTensor::validate(const Kernel& kernel, const Ex& pat) const
 	// We cannot access the right things from parse()
 	if(ind) {
 		WeylTensor *ptr = const_cast<WeylTensor*>(this);
-		ptr->index_set_name=ind->set_name;
+		ptr->index_set_names.insert(ind->set_name);
 		}
 	}
 


### PR DESCRIPTION
This revises the previous patches that deal with index set names to be more in line with Cadabra conventions.