### PR TITLE
Py-Jupyter bugfixes and sandboxing

### DIFF
--- a/jupyterkernel/cadabra2_jupyter/context.py
+++ b/jupyterkernel/cadabra2_jupyter/context.py
@@ -21,12 +21,14 @@ class _StdCatch:
         sys.stderr = sys.__stderr__
 
         for line in self.stdout.getvalue().splitlines():
-            self._kernel._send_code(line)
+            # insert missing newline
+            self._kernel._send_code(line + "\n")
 
         # ignore exc_type reporting, since it always gives 'JSON serializable'
         # error, echoing the same message as provided by the __stderr__ catch
         for line in self.stderr.getvalue().splitlines():
-            self._kernel._send_error(line)
+            # insert missing newline
+            self._kernel._send_error(line + "\n")
 
 
 class SandboxContext:

--- a/jupyterkernel/cadabra2_jupyter/context.py
+++ b/jupyterkernel/cadabra2_jupyter/context.py
@@ -37,3 +37,7 @@ class SandboxContext:
     def __call__(self, code):
         with _StdCatch():
             exec(code, self._sandbox)
+
+    @property
+    def namespace(self):
+        return self._sandbox.keys()

--- a/jupyterkernel/cadabra2_jupyter/context.py
+++ b/jupyterkernel/cadabra2_jupyter/context.py
@@ -9,33 +9,43 @@ __cdbkernel__ = cadabra2.__cdbkernel__
 
 #  setup stdout, stderr hook
 class _StdCatch:
+    def __init__(self, kernel):
+        self._kernel = kernel
+
     def __enter__(self):
         sys.stdout = self.stdout = StringIO()
         sys.stderr = self.stderr = StringIO()
 
     def __exit__(self, exc_type, exc_val, exc_traceback):
-        global server
         sys.stdout = sys.__stdout__
         sys.stderr = sys.__stderr__
 
         for line in self.stdout.getvalue().splitlines():
-            server._kernel._send_code(line)
+            self._kernel._send_code(line)
 
         # ignore exc_type reporting, since it always gives 'JSON serializable'
         # error, echoing the same message as provided by the __stderr__ catch
         for line in self.stderr.getvalue().splitlines():
-            server._kernel._send_error(line)
+            self._kernel._send_error(line)
 
 
 class SandboxContext:
-    def __init__(self, server):
-        self._sandbox = {"server": server, "__cdbkernel__": cadabra2.__cdbkernel__}
+    def __init__(self, kernel):
+        self._sandbox = {
+            "server": kernel._cdb_server,
+            "__cdbkernel__": cadabra2.__cdbkernel__,
+        }
         with open(os.path.join(SITE_PATH, "cadabra2_defaults.py")) as f:
             code = compile(f.read(), "cadabra2_defaults.py", "exec")
         exec(code, self._sandbox)
 
+        self._kernel = kernel
+        self._context = _StdCatch(kernel)
+
     def __call__(self, code):
-        with _StdCatch():
+        # redefine, as is catastrophic if accidentally overwritten
+        self._sandbox["server"] = self._kernel._cdb_server
+        with self._context:
             exec(code, self._sandbox)
 
     @property

--- a/jupyterkernel/cadabra2_jupyter/kernel.py
+++ b/jupyterkernel/cadabra2_jupyter/kernel.py
@@ -35,7 +35,7 @@ class CadabraJupyterKernel(ipykernel.kernelbase.Kernel):
         self._cdb_server = Server(self)
 
         # init the sandbox
-        self._sandbox_context = SandboxContext(self._cdb_server)
+        self._sandbox_context = SandboxContext(self)
 
     def do_execute(
         self, code, silent, store_history=True, user_expressions=None, allow_stdin=False

--- a/jupyterkernel/cadabra2_jupyter/server.py
+++ b/jupyterkernel/cadabra2_jupyter/server.py
@@ -5,7 +5,7 @@ class Server:
     def send(self, data, typestr, parent_id, last_in_sequence):
         if typestr == "latex_view":
             data = data.replace("\\begin{dmath*}", "$").replace("\\end{dmath*}", "$")
-            data = data.replace("\\discretionary{}{}{}", "").replace("~","")
+            data = data.replace("\\discretionary{}{}{}", "").replace("~", "")
             self._kernel._send_result(data)
         elif typestr == "image_png":
             # todo

--- a/jupyterkernel/cadabra2_jupyter/server.py
+++ b/jupyterkernel/cadabra2_jupyter/server.py
@@ -1,11 +1,19 @@
+def _latex_post_parser(text):
+    return (
+        text.replace("\\begin{dmath*}", "$")
+        .replace("\\end{dmath*}", "$")
+        .replace("\\discretionary{}{}{}", "")
+        .replace("~", "")
+    )
+
+
 class Server:
     def __init__(self, kernel_instance):
         self._kernel = kernel_instance
 
     def send(self, data, typestr, parent_id, last_in_sequence):
         if typestr == "latex_view":
-            data = data.replace("\\begin{dmath*}", "$").replace("\\end{dmath*}", "$")
-            data = data.replace("\\discretionary{}{}{}", "").replace("~", "")
+            data = _latex_post_parser(data)
             self._kernel._send_result(data)
         elif typestr == "image_png":
             # todo

--- a/jupyterkernel/lexer/cadabra2.py
+++ b/jupyterkernel/lexer/cadabra2.py
@@ -1,0 +1,22 @@
+""" very basic implementation of a pygments lexer for Cadabra2 """
+
+from pygments.lexers import Python3Lexer
+import pygments.token as token
+
+__all__ = ["CadabraLexer"]
+
+CADABRA_ROOT = [
+    (r"::[\w\d]*", token.Keyword), # property attaches
+    (r"\S#}", token.Text), # some comment exceptions
+    (r"[;.]\s*$", token.Operator) # ; . operators
+] + Python3Lexer.tokens['root']
+
+class CadabraLexer(Python3Lexer):
+    name="Cadabra",
+    aliases=["cadabra","cadabra2"]
+    filenames="*.cdb"
+
+    tokens = {
+        **Python3Lexer.tokens,
+        **{'root':CADABRA_ROOT}
+    }


### PR DESCRIPTION
### Summary
- fixes bug where `print()` statements aren't being shown in notebook
- sandboxes the execution environment so that the kernel cannot be modified by the user
- adds basic code completion determined by the current namespace

### Details
- `print()` capture

The previously merged kernel doesn't capture `stdout`/`stderr`, so unless terminated by `;`, or calling `display` directly, no output would be returned to the cell. By using a context wrap, the general output of the kernel is captured, with the streams being sent back to the user. 

- sandboxing

Prior to these commits, we make use of `exec(code, globals())` calls to execute the parsed cadabra code -- this works perfectly fine, however allows the user to (accidentally) seriously disrupt the kernel messaging system, e.g. by assigning to `server`.  To fix this, I've implemented a `SandboxContext`, which uses a Python dictionary to hold onto the user's namespace, without polluting it with the kernel's own. The user consequently no longer has access to the kernel context. Similarly, the `server` instance is reassigned in the sandbox before each cell execution, so at the *very* least, runtime errors are still reported. 

- code completion

I've added a very basic code completion callback, which just matches the currently typed code with code in the sandboxed namespace. Momentarily, there is no concept of Cadabra properties, or algorithms, beyond what is imported from `cadabra2_defaults.py`, but it still aids with typing 😊

As a final note, I've started working on a `pygments` lexer for Cadabra2, for use in the syntax highlighting with the jupyter kernel, and have included it in this PR, despite not having found a satisfactory way to install it yet.

