### PR TITLE
Py-Jupyter syntax and smarter completion

### DIFF
--- a/jupyterkernel/CMakeLists.txt
+++ b/jupyterkernel/CMakeLists.txt
@@ -27,6 +27,7 @@ install(FILES
    cadabra2_jupyter/__init__.py
    cadabra2_jupyter/__main__.py
    cadabra2_jupyter/context.py
+   cadabra2_jupyter/completer.py
    cadabra2_jupyter/kernel.py
    cadabra2_jupyter/server.py
    DESTINATION

--- a/jupyterkernel/CMakeLists.txt
+++ b/jupyterkernel/CMakeLists.txt
@@ -27,8 +27,14 @@ install(FILES
    cadabra2_jupyter/__init__.py
    cadabra2_jupyter/__main__.py
    cadabra2_jupyter/context.py
-   cadabra2_jupyter/kernel.py   
-   cadabra2_jupyter/server.py      
+   cadabra2_jupyter/kernel.py
+   cadabra2_jupyter/server.py
    DESTINATION
    "${PYTHON_SITE_PATH}/cadabra2_jupyter"
    )
+
+install(FILES
+  lexer/cadabra.js
+  DESTINATION
+  "${PYTHON_SITE_PATH}/notebook/static/components/codemirror/mode/cadabra"
+  )

--- a/jupyterkernel/cadabra2_jupyter/completer.py
+++ b/jupyterkernel/cadabra2_jupyter/completer.py
@@ -74,11 +74,10 @@ class CodeCompleter:
     def __call__(self, code, cursor_pos, namespace):
         # only choose up until current cursor position
         self.code = code[:cursor_pos]
-        print(self.code)
 
         last = self.get_last_word()
         matched_klass = self.get_class()
-        print("matched: ", matched_klass)
+
         if self.cursor_on_property(last):
             # cursor on cadabra property
             if last:

--- a/jupyterkernel/cadabra2_jupyter/completer.py
+++ b/jupyterkernel/cadabra2_jupyter/completer.py
@@ -43,12 +43,17 @@ properties = [
 
 
 import re
+import string
 
 
 class CodeCompleter:
     def __init__(self, kernel):
         self._kernel = kernel
         self.code = ""
+
+    @property
+    def triggers(self):
+        return string.ascii_letters + ":;."
 
     def get_last_word(self):
         return re.compile(r"[\W\s]").split(self.code)[-1]
@@ -65,7 +70,8 @@ class CodeCompleter:
     def match_member(self, last, klass):
         """ matches last word in the namespace of the currently selected class """
         instance = self._kernel._sandbox_context._sandbox[klass]
-        return self.match(last, dir(instance))
+        #  filter out hidden namespace, unless typing hidden namespace
+        return self.match(last, (i for i in dir(instance) if "__" not in i))
 
     def get_class(self):
         """ get class currently behind cursor  """

--- a/jupyterkernel/cadabra2_jupyter/completer.py
+++ b/jupyterkernel/cadabra2_jupyter/completer.py
@@ -1,0 +1,93 @@
+""" keywords scraped from cadabra.science/man.html """
+
+properties = [
+    "Accent",
+    "AntiCommuting",
+    "AntiSymmetric",
+    "Commuting",
+    "CommutingAsProduct",
+    "CommutingAsSum",
+    "Coordinate",
+    "DAntiSymmetric",
+    "Depends",
+    "Derivative",
+    "Determinant",
+    "Diagonal",
+    "DiracBar",
+    "EpsilonTensor",
+    "FilledTableau",
+    "GammaMatrix",
+    "ImplicitIndex",
+    "IndexInherit",
+    "Indices",
+    "Integer",
+    "InverseMetric",
+    "KroneckerDelta",
+    "LaTeXForm",
+    "Metric",
+    "NonCommuting",
+    "PartialDerivative",
+    "RiemannTensor",
+    "SatisfiesBianchi",
+    "SelfAntiCommuting",
+    "SelfCommuting",
+    "SelfNonCommuting",
+    "SortOrder",
+    "Spinor",
+    "Symbol",
+    "Symmetric",
+    "Tableau",
+    "TableauSymmetry",
+    "WeightInherit",
+]
+
+
+import re
+
+
+class CodeCompleter:
+    def __init__(self, kernel):
+        self._kernel = kernel
+        self.code = ""
+
+    def get_last_word(self):
+        return re.compile(r"[\W\s]").split(self.code)[-1]
+
+    def cursor_on_property(self, last):
+        search_query = re.compile(".*::{}$".format(last), re.MULTILINE)
+        return re.search(search_query, self.code)
+
+    def match(self, last, options):
+        opts = list(filter(lambda i: re.match("^{}.*".format(last), i), options))
+        # return options and length of the last matched word
+        return opts, len(last)
+
+    def match_member(self, last, klass):
+        """ matches last word in the namespace of the currently selected class """
+        instance = self._kernel._sandbox_context._sandbox[klass]
+        return self.match(last, dir(instance))
+
+    def get_class(self):
+        """ get class currently behind cursor  """
+        return re.findall(r"(\w+)\.\w*$", self.code)
+
+    def __call__(self, code, cursor_pos, namespace):
+        # only choose up until current cursor position
+        self.code = code[:cursor_pos]
+        print(self.code)
+
+        last = self.get_last_word()
+        matched_klass = self.get_class()
+        print("matched: ", matched_klass)
+        if self.cursor_on_property(last):
+            # cursor on cadabra property
+            if last:
+                return self.match(last, properties)
+            else:
+                return properties, 0
+
+        elif matched_klass and matched_klass[-1] in namespace:
+            # cursor on member function
+            return self.match_member(last, matched_klass[-1])
+        else:
+            return self.match(last, namespace)

--- a/jupyterkernel/cadabra2_jupyter/kernel.py
+++ b/jupyterkernel/cadabra2_jupyter/kernel.py
@@ -70,7 +70,7 @@ class CadabraJupyterKernel(ipykernel.kernelbase.Kernel):
         """ callback for iPython kernel: code completion """
 
         # if no code, or last character is whitespace
-        if not code or code[-1] == " ":
+        if not code or code[-1] not in self._completer.triggers:
             return self._default_complete(cursor_pos)
 
         # sandbox namespace

--- a/jupyterkernel/cadabra2_jupyter/kernel.py
+++ b/jupyterkernel/cadabra2_jupyter/kernel.py
@@ -17,9 +17,9 @@ class CadabraJupyterKernel(ipykernel.kernelbase.Kernel):
     implementation_version = __version__
     language_info = {
         "name": "cadabra2",
-        "codemirror_mode": "cadabra2",
-        "pygments_lexer": "cadabra2",
-        "mimetype": "text/cadabra2",
+        "codemirror_mode": "cadabra",
+        "pygments_lexer": "cadabra",
+        "mimetype": "text/cadabra",
         "file_extension": ".ipynb",
     }
 

--- a/jupyterkernel/cadabra2_jupyter/kernel.py
+++ b/jupyterkernel/cadabra2_jupyter/kernel.py
@@ -1,15 +1,12 @@
 import ipykernel.kernelbase
 import sys
 import traceback
-import re
-import string
 
 import cadabra2
 from cadabra2_jupyter.context import SandboxContext
 from cadabra2_jupyter.server import Server
+from cadabra2_jupyter.completer import CodeCompleter
 from cadabra2_jupyter import __version__
-
-_accepted_chars = string.ascii_letters
 
 
 class CadabraJupyterKernel(ipykernel.kernelbase.Kernel):
@@ -36,6 +33,9 @@ class CadabraJupyterKernel(ipykernel.kernelbase.Kernel):
 
         # init the sandbox
         self._sandbox_context = SandboxContext(self)
+
+        # init code completion
+        self._completer = CodeCompleter(self)
 
     def do_execute(
         self, code, silent, store_history=True, user_expressions=None, allow_stdin=False
@@ -69,26 +69,17 @@ class CadabraJupyterKernel(ipykernel.kernelbase.Kernel):
     def do_complete(self, code, cursor_pos):
         """ callback for iPython kernel: code completion """
 
-        # if no code, or last character is not alphabetical
-        if not code or code[cursor_pos - 1] not in _accepted_chars:
+        # if no code, or last character is whitespace
+        if not code or code[-1] == " ":
             return self._default_complete(cursor_pos)
-
-        # only choose up until current cursor position
-        code = code[:cursor_pos]
-
-        # get last 'word' item
-        last_item = re.compile(r"[\W\s]").split(code)[-1]
 
         # sandbox namespace
         namespace = self._sandbox_context.namespace
 
-        # find valid options
-        options = list(
-            filter(lambda i: re.match("^{}.*".format(last_item), i), namespace)
-        )
+        options, rewind = self._completer(code, cursor_pos, namespace)
         return {
             "matches": sorted(options),
-            "cursor_start": cursor_pos - len(last_item),
+            "cursor_start": cursor_pos - rewind,
             "cursor_end": cursor_pos,
             "status": "ok",
             "metadata": dict(),

--- a/jupyterkernel/lexer/cadabra.js
+++ b/jupyterkernel/lexer/cadabra.js
@@ -1,0 +1,127 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: https://codemirror.net/LICENSE
+
+// Adapted by Fergus Baker for Cadabra 2 (c) Kasper Peeters
+
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+  "use strict";
+
+  // lexing starts here!
+  CodeMirror.defineMode('cadabra', function(cfg, cfg_parser) {
+    // use the python code mirror mode
+    var pythonmode = CodeMirror.getMode(cfg, {name:'python'});
+
+    function isWhitespace(char) {
+      return !(char) || char == ' ' || char == '\n' || char == '\t'
+    }
+
+    function eatWord(stream) {
+      var count = 0;
+      while(stream.eat(/[\w\d]+/g)){
+        // eat word
+        count++;
+      }
+      return count;
+    }
+
+    function cadabraToken(stream, state) {
+      // big long basic if/else parser
+
+      // get current token string
+      var current = stream.current()
+
+      if (current.match(/#/)) {
+        if (stream.indentation()) {
+          // python comment
+          return 'python';
+        } else {
+          // escape python comments
+          stream.backUp(current.length-1);
+          return null;
+        }
+      }
+      else if (current.match(/:/g)) {
+        if (stream.peek() == ':') {
+          // handle property assign operator
+          stream.next();
+          // eat property
+          eatWord(stream);
+          return 'builtin';
+        } else if (stream.peek() == '=') {
+          // handle walrus assign operator
+          stream.next();
+          return 'operator';
+        }
+      }
+      else if (current.match(/[.;]$/gm)) {
+        if ( isWhitespace(stream.peek()) ) {
+          return 'operator';
+        }
+      }
+      else if (current.match(/_/g)) {
+        // handle lowering indices operator
+        // ensure stream not in variable
+        if (current.length > 1) {
+          stream.backUp(1);
+          return null;
+        }
+        if (stream.peek() == '{') {
+          return 'operator'
+        }
+      }
+      else if (current.match(/\$/g)) {
+        // cadabra lambdas
+        return 'def';
+      }
+      else if (current.match(/\\/)) {
+        var count = eatWord(stream);
+        current = stream.current();
+        if (current.match(/(lambda|int)/g)) {
+          return null;
+        } else {
+          stream.backUp(count);
+          return 'python';
+        }
+
+      }
+      else {
+        // leave alone
+        return 'python';
+      }
+    }
+
+    // global multiline match triggers; this could probably be done more
+    // efficiently with doing explicit checks for positioning, but this code
+    // doesn't need to run particularly fast, so for convenience
+    // grouping together
+    const triggers = /[:#_;.$\\]/gm
+
+    return {
+      startState: () => {
+        // init python mode, cadabra mode doesn't need state
+        return pythonmode.startState();
+      },
+      token: (stream, state) => {
+        var ret = pythonmode.token(stream, state);
+
+        // cadabra parse if triggered
+        if (stream.current().match(triggers)) {
+          var cdb_ret = cadabraToken(stream, state);
+          ret = cdb_ret !== 'python' ? cdb_ret : ret;
+        }
+        return ret;
+      },
+      indent: (state, textAfter) => {
+        // let python handle indents
+        return pythonmode.indent(state, textAfter);
+      }
+    }
+  });
+});

--- a/jupyterkernel/lexer/cadabra.js
+++ b/jupyterkernel/lexer/cadabra.js
@@ -37,6 +37,11 @@
       // get current token string
       var current = stream.current()
 
+      // ignore if string; use lookbehind to see if escaped
+      if (current.match(/(?<!\\)".*(?<!\\)"/g)) {
+        return 'python';
+      }
+
       if (current.match(/#/)) {
         if (stream.indentation()) {
           // python comment
@@ -119,6 +124,10 @@
         return ret;
       },
       indent: (state, textAfter) => {
+        // so that properties don't indent oddly
+        console.log(state);
+        if (state.lastToken == ':') return 0;
+
         // let python handle indents
         return pythonmode.indent(state, textAfter);
       }

--- a/jupyterkernel/lexer/cadabra.js
+++ b/jupyterkernel/lexer/cadabra.js
@@ -53,12 +53,13 @@
         }
       }
       else if (current.match(/:/g)) {
+        // don't indent; have to update scopes
+
         if (stream.peek() == ':') {
           // handle property assign operator
-
-          // don't indent; have to update scopes
           state.lastToken="::"
           state.scopes.pop();
+
           // consume second :
           stream.next();
           // eat property
@@ -66,9 +67,13 @@
           return 'builtin';
         } else if (stream.peek() == '=') {
           // handle walrus assign operator
+          state.lastToken=":="
+          state.scopes.pop();
+
           stream.next();
           return 'operator';
-        }
+
+        } else return 'python';
       }
       else if (current.match(/[.;]$/gm)) {
         if ( isWhitespace(stream.peek()) ) {
@@ -131,6 +136,7 @@
       indent: (state, textAfter) => {
         // so that properties don't indent oddly
 
+        console.log(state);
         if (state.lastToken == '::') return 0;
 
         // let python handle indents

--- a/jupyterkernel/lexer/cadabra.js
+++ b/jupyterkernel/lexer/cadabra.js
@@ -55,6 +55,11 @@
       else if (current.match(/:/g)) {
         if (stream.peek() == ':') {
           // handle property assign operator
+
+          // don't indent; have to update scopes
+          state.lastToken="::"
+          state.scopes.pop();
+          // consume second :
           stream.next();
           // eat property
           eatWord(stream);
@@ -125,8 +130,8 @@
       },
       indent: (state, textAfter) => {
         // so that properties don't indent oddly
-        console.log(state);
-        if (state.lastToken == ':') return 0;
+
+        if (state.lastToken == '::') return 0;
 
         // let python handle indents
         return pythonmode.indent(state, textAfter);

--- a/jupyterkernel/lexer/cadabra.py
+++ b/jupyterkernel/lexer/cadabra.py
@@ -1,17 +1,17 @@
 """ very basic implementation of a pygments lexer for Cadabra2 """
 
-from pygments.lexers import Python3Lexer
+from pygments.lexers import PythonLexer
 import pygments.token as token
 
 __all__ = ["CadabraLexer"]
 
 CADABRA_ROOT = [
     (r"::[\w\d]*", token.Keyword), # property attaches
-    (r"\S#}", token.Text), # some comment exceptions
-    (r"[;.]\s*$", token.Operator) # ; . operators
+    (r"\S#}.*", token.Text), # some comment exceptions
+    (r"[;.(:=)]\s*$", token.Operator) # ; . operators
 ] + Python3Lexer.tokens['root']
 
-class CadabraLexer(Python3Lexer):
+class CadabraLexer(PythonLexer):
     name="Cadabra",
     aliases=["cadabra","cadabra2"]
     filenames="*.cdb"

--- a/jupyterkernel/readme.txt
+++ b/jupyterkernel/readme.txt
@@ -1,0 +1,14 @@
+Py-Jupyter Cadabra2 Kernel
+
+Features:
+  - latex filtered output
+  - syntax highlighting and indentation with CodeMirror
+  - code completion on tab press
+  - sandboxed and sequential execution
+
+Todo:
+  - images/figures
+  - code inspection with ? (at the moment can only use `help`)
+  - input html widgets
+  - neaten lexers; momentarily written as learning so not very clean
+  - magic commands for kernel control 


### PR DESCRIPTION
### Summary

- CodeMirror lexer for syntax highlighting
- completion now looks in context-specific namespaces
- bunch of bugfixes

### Details

- CodeMirror lexer

I found a way of extending the existing python lexer to also highlight cadabra syntax, and track indentation level. It isn't cadabra keyword aware (instead using regex rules to identified cadabra syntax), but with the code completion that doesn't prove too problematic, as it limits the ability to mistype.

- code completion

I copied a list of cadabra `::properties` from the manual and made the code completer aware of them, so that it can suggest them over the general namespace. I left this out for the algorithms, since they already exist as python functions by (mostly?entirely?) the same names. Additionally, if addressing members of an object with e.g. `obj.<tab>` it will now search `dir(obj)` for the completion, so that typing is again less error prone.


With this PR, the kernel is in pretty good shape -- going to take a break from development now 🤓