### PR TITLE
Small CodeMirror change

### DIFF
--- a/jupyterkernel/lexer/cadabra.js
+++ b/jupyterkernel/lexer/cadabra.js
@@ -35,22 +35,26 @@
       // big long basic if/else parser
 
       // get current token string
-      var current = stream.current()
+      var current = stream.current();
 
       // ignore if string; use lookbehind to see if escaped
-      if (current.match(/(?<!\\)".*(?<!\\)"/g)) {
+      if (current.match(/^(?<!\\)".*(?<!\\)"/g)) {
         return 'python';
       }
 
       if (current.match(/#/)) {
-        if (stream.indentation()) {
+        // comments must have "# [text]", else considered as operators.
+        if (stream.indentation() == stream.column()) {
           // python comment
           return 'python';
         } else {
           // escape python comments
           stream.backUp(current.length-1);
-          return null;
+          return "operator";
         }
+      }
+      else if (current.match(/\?/g)) {
+        return 'operator';
       }
       else if (current.match(/:/g)) {
         // don't indent; have to update scopes
@@ -116,7 +120,7 @@
     // efficiently with doing explicit checks for positioning, but this code
     // doesn't need to run particularly fast, so for convenience
     // grouping together
-    const triggers = /[:#_;.$\\]/gm
+    const triggers = /[\?:#_;.$\\]/gm
 
     return {
       startState: () => {


### PR DESCRIPTION
## Summary

A quick bugfix for comment highlighting in the Jupyter kernel, and operator highlights for `?` and `??` wildcards.
## Details
The old CodeMirror mode for Cadabra2 doesn't highlight uses of `#` correctly.

I'm a little confused as to how comments are used in Cadabra2, given the `#` operator for indices, however, this commit ammends the CodeMirror lexer to *define a comment* as any string obeying `^\s*#`, in accordance to 
> Any line starting with a "\#" sign is considered to be a comment (even when it appears within a multi-line expression). Comments are always ignored completely (they do not end up in the expression tree.

from the [manpage on input formats](https://cadabra.science/notebooks/input_format.html).

That is to say
```
# this is a valid comment 
    # this is a valid comment

\lorem{} # this is not a valid comment (cadabra2 parse error)
print("Hello") # this is also not a valid comment (although technically python valid)
```
and common uses like
```
\dg{#}::LaTeXForm("\delta g").
{a, b, c, u#}::Indices().
```
will highlight correctly with `#` as an operator, with comments written on seperate lines:
```
# This is my comment...
\dg{#}::LaTeXForm("\delta g").
# ... and here's another.
{a, b, c, u# }::Indices().
```