### PR TITLE
Fixed join to avoid crashing on empty lists

### DIFF
--- a/core/pythoncdb/py_ex.cc
+++ b/core/pythoncdb/py_ex.cc
@@ -145,6 +145,10 @@ namespace cadabra {
 				}
 			}
 		// Note: ret could still \comma{} or \comma{x}
+		auto it = ret->begin();
+		if (ret->number_of_children(it) < 2) {
+			ret->flatten_and_erase(it);
+			}
 		return ret;
 		}
 	

--- a/core/pythoncdb/py_ex.cc
+++ b/core/pythoncdb/py_ex.cc
@@ -137,10 +137,14 @@ namespace cadabra {
 		auto ret = std::make_shared<Ex>("\\comma");
 
 		for(const Ex_ptr& ex: exs) {
-			auto loc = ret->append_child(ret->begin(), ex->begin());
-			if(*ex->begin()->name=="\\comma") 
-				ret->flatten_and_erase(loc);
+			// skip ex if empty
+			if (ex->size() > 0) {
+				auto loc = ret->append_child(ret->begin(), ex->begin());
+				if(*ex->begin()->name=="\\comma") 
+					ret->flatten_and_erase(loc);
+				}
 			}
+		// Note: ret could still \comma{} or \comma{x}
 		return ret;
 		}
 	


### PR DESCRIPTION
The vectored join implementation in Ex_join crashes when one of the expressions is empty. I added a size() check (as in the old version of join). 

Note: This version will return an empty list \comma{} or a single element list \comma{x} if it is passed an empty expression as an argument. Should that be permitted?