### PR TITLE
Backport pybind11 bugfix

### DIFF
--- a/libs/pybind11/include/pybind11/pybind11.h
+++ b/libs/pybind11/include/pybind11/pybind11.h
@@ -57,11 +57,13 @@ inline std::string replace_newlines_and_squash(const char *text) {
     std::string result(text);
     bool previous_is_whitespace = false;
 
-    // Do not modify string representations
-    char first_char = result[0];
-    char last_char = result[result.size() - 1];
-    if (first_char == last_char && first_char == '\'') {
-        return result;
+    if (result.size() >= 2) {
+        // Do not modify string representations
+        char first_char = result[0];
+        char last_char = result[result.size() - 1];
+        if (first_char == last_char && first_char == '\'') {
+            return result;
+        }
     }
     result.clear();
 


### PR DESCRIPTION
The last time pybind11 was copied over, it had a small bug which was fixed upstream a month later. This caused cadabra2 to fail with a runtime error when built with -D_GLIBCXX_ASSERTIONS which is the default on some distros.