### PR TITLE
Cleanup for the Indices property

### DIFF
--- a/core/properties/Indices.cc
+++ b/core/properties/Indices.cc
@@ -76,19 +76,22 @@ bool Indices::parse(Kernel& kernel, std::shared_ptr<Ex> ex, keyval_t& keyvals)
 			// If all values are indices, add an `Integer' property for the object,
 			// listing these integers.
 			bool is_number=true;
+			bool is_continuous=false;
 			for(auto& val: values)
 				if(!val.begin()->is_integer()) {
 					is_number=false;
 					break;
 					}
-			// FIXME: the above assumes no gap in the integer range, which is
-			// not always guaranteed, and will then break the Integer property
-			// assignment as the latter can only deal with continuous ranges.
 			if(is_number) {
-				Ex from(values[0]), to(values[values.size()-1]);
+				std::sort(values.begin(), values.end(), [](Ex a, Ex b) {
+					return a.to_integer() < b.to_integer();
+					});
+				is_continuous = (int)values.size() == (values[values.size() - 1].to_integer() - values[0].to_integer() + 1);
+				}
+			// FIXME: do not apply Integer to a list of integers with gaps as
+			// the former can only deal with continuous ranges.
+			if(is_continuous) {
 //				std::cerr << "Injecting Integer property" << std::endl;
-				// FIXME: this assumes that the values are in a continuous range (as Integer cannot
-				// represent anything else at this stage).
 				kernel.inject_property(new Integer(), ex,
 											  kernel.ex_from_string(std::to_string(values[0].to_integer())+".."
 																			+std::to_string(values[values.size()-1].to_integer())

--- a/core/properties/Indices.cc
+++ b/core/properties/Indices.cc
@@ -67,12 +67,22 @@ bool Indices::parse(Kernel& kernel, std::shared_ptr<Ex> ex, keyval_t& keyvals)
 			//std::cerr << "got values keyword " << *(ki->second->name) << std::endl;
 			if(*ki->second->name=="\\sequence") {
 				auto args = std::make_shared<cadabra::Ex>(ki->second);
-				kernel.inject_property(new Integer(), ex, args);
+				auto prop = new Integer();
+				kernel.inject_property(prop, ex, args);
+
+				if (prop->from.is_integer() && prop->to.is_integer()) {
+					if (prop->difference.to_integer() < 100) {
+						for (int i=prop->from.to_integer(); i<=prop->to.to_integer(); ++i) {
+							values.push_back(Ex(i));
+							}
+						}
+					}
+
 				++ki;
 				continue;
 				}
-			collect_index_values(ki->second);
 
+			collect_index_values(ki->second);
 			// If all values are indices, add an `Integer' property for the object,
 			// listing these integers.
 			bool is_number=true;

--- a/core/properties/Indices.cc
+++ b/core/properties/Indices.cc
@@ -65,6 +65,12 @@ bool Indices::parse(Kernel& kernel, std::shared_ptr<Ex> ex, keyval_t& keyvals)
 			}
 		else if(ki->first=="values") {
 			//std::cerr << "got values keyword " << *(ki->second->name) << std::endl;
+			if(*ki->second->name=="\\sequence") {
+				auto args = std::make_shared<cadabra::Ex>(ki->second);
+				kernel.inject_property(new Integer(), ex, args);
+				++ki;
+				continue;
+				}
 			collect_index_values(ki->second);
 
 			// If all values are indices, add an `Integer' property for the object,
@@ -125,24 +131,6 @@ void Indices::validate(const Kernel& k, const Ex& ex) const
 
 void Indices::collect_index_values(Ex::iterator ind_values)
 	{
-	if(*ind_values->name=="\\sequence") {
-		// We have been given a sequence, not a list.
-		// FIXME: guard against errors or large ranges.
-		auto ch = Ex::begin(ind_values);
-		size_t start = to_long(*ch->multiplier);
-		++ch;
-		size_t end   = to_long(*ch->multiplier);
-		if(end<start)
-			throw ArgumentException("Index range must be increasing.");
-		if(end-start > 100)
-			throw ArgumentException("Number of index values larger than 100, probably a typo.");
-			
-		for(size_t i=start; i<=end; ++i) {
-			values.push_back(Ex(i));
-			}
-		return;
-		}
-	
 	Ex tmp;
 	cadabra::do_list(tmp, ind_values, [&](Ex::iterator ind) {
 		values.push_back(Ex(ind));

--- a/core/properties/Indices.cnb
+++ b/core/properties/Indices.cnb
@@ -196,7 +196,7 @@
 			"cell_id": 9717721989471119742,
 			"cell_origin": "client",
 			"cell_type": "input",
-			"source": "{x,y,z}::Coordinate.\n{a,b,c}::Indices(values={x,y,z}).\n{m,n,p}::Indices(values={0,1,2}).\n{q,r,s}::Indices(values={0..3})."
+			"source": "{x,y,z}::Coordinate.\n{a,b,c}::Indices(values={x,y,z}).\n{d,e,f}::Indices(values={0,1,3}).\n{m,n,p}::Indices(values={0,1,2}).\n{q,r,s}::Indices(values={0..3})."
 		},
 		{
 			"cell_id": 5245275082540183677,
@@ -207,11 +207,11 @@
 					"cell_id": 16921403430064941369,
 					"cell_origin": "client",
 					"cell_type": "latex_view",
-					"source": "When the values specified here are integers, an automatic \\prop{Integer} property will\nbe generated that reflects these values. So e.g. the third line above leads to an \nautomatic attachment"
+					"source": "When values is a sequence or a list of integers with no gaps, an automatic \n\\prop{Integer} property will be generated that reflects these values. So e.g. the \nlast line above (but not the middle line) leads to an automatic attachment"
 				}
 			],
 			"hidden": true,
-			"source": "When the values specified here are integers, an automatic \\prop{Integer} property will\nbe generated that reflects these values. So e.g. the fourth line above leads to an \nautomatic attachment"
+			"source": "When values is a sequence or a list of integers with no gaps, an automatic \n\\prop{Integer} property will be generated that reflects these values. So e.g. the \nlast line above (but not the middle line) leads to an automatic attachment"
 		},
 		{
 			"cell_id": 16647378988601399263,

--- a/tests/dummies.cdb
+++ b/tests/dummies.cdb
@@ -85,3 +85,20 @@ def test06():
    print("Test 06 passed")
 
 test06()
+
+# values tests
+
+def test07():
+   __cdbkernel__ = create_scope()
+   {a, b}::Indices(values={-1..2}).
+   {c, d}::Indices(values={-1,1,2}).
+   \delta{#}::KroneckerDelta.
+   ex1 := \delta_{a b} \delta_{a b}.
+   eliminate_kronecker(ex1)
+   assert ex1 == 4
+   ex2 := \delta_{c d} \delta_{c d}.
+   eliminate_kronecker(ex2)
+   assert ex2 == $\delta_{d d}$
+   print("Test 07 passed")
+
+test07()


### PR DESCRIPTION
If you can get the Integer property applied by passing a certain sequence to Integer, you should also be able to get it applied by passing the same sequence to Indices. For non-sequence arguments, this also checks that the values are continuous using a simple lambda function.