### PR TITLE
Fix: update Jupyter kernel send function

### DIFF
--- a/jupyterkernel/cadabra2_jupyter/server.py
+++ b/jupyterkernel/cadabra2_jupyter/server.py
@@ -11,7 +11,7 @@ class Server:
     def __init__(self, kernel_instance):
         self._kernel = kernel_instance
 
-    def send(self, data, typestr, parent_id, last_in_sequence):
+    def send(self, data, typestr, parent_id, cell_id, last_in_sequence):
         if typestr == "latex_view":
             data = _latex_post_parser(data)
             self._kernel._send_result(data)


### PR DESCRIPTION
Fixes an issue @inaki-ortizdelandaluce opened on a Dockerfile wrapper I maintain: https://github.com/fjebaker/cadabra-resources/issues/1

The Server API was updated some months ago, but not in the Jupyter kernel, leading to runtime errors.

I have been planning to revisit the Jupyter kernel, modernize it, and flesh out the features I never got round to implementing, but I am yet to find the time... hopefully soon!