### PR TITLE
Added caching for substitute rules. Made substitute args pass-by-refe…

### DIFF
--- a/core/algorithms/substitute.hh
+++ b/core/algorithms/substitute.hh
@@ -35,6 +35,35 @@ namespace cadabra {
 			virtual result_t apply(iterator&);
 
 			Ex_comparator comparator;
+			
+			// Rules is a class for caching properties of substitution rules to avoid
+			// processing them in subsequent calls
+			class Rules {
+				public:
+					// Associate rule properties with a specific object
+					void store(Ex& rules, std::map<iterator, bool>& lhs_contains_dummies, std::map<iterator, bool>& rhs_contains_dummies);
+					// Check if rules are present
+					bool is_present(Ex& rules);
+					// Retrieve properties from rules
+					void retrieve(Ex& rules, std::map<iterator, bool>& lhs_contains_dummies, std::map<iterator, bool>& rhs_contains_dummies);
+					// Count number of rules
+					int size();
+					// Eliminate rules that are expired
+					void cleanup();
+
+				private:
+					// Map storing weak pointers to `Ex` and pairs of lhs/rhs maps as values
+					std::map<std::weak_ptr<Ex>, 
+								std::pair<std::map<iterator, bool>, std::map<iterator, bool>>, 
+								std::owner_less<std::weak_ptr<Ex>>> properties;
+
+					// Initial size threshold to trigger cleanup_rules
+					unsigned int cleanup_threshold = 100;
+					// Store max size of the rules list to avoid it getting out of hand
+					unsigned int max_size = 1000;
+				};
+
+
 		private:
 			Ex&        args;
 
@@ -48,4 +77,9 @@ namespace cadabra {
 			bool            partial;
 		};
 
+	/* Global instance of substitute::rules */
+	extern substitute::Rules global_rules;
+
 	}
+
+	

--- a/core/algorithms/substitute.hh
+++ b/core/algorithms/substitute.hh
@@ -78,7 +78,7 @@ namespace cadabra {
 		};
 
 	/* Global instance of substitute::rules */
-	extern substitute::Rules global_rules;
+	extern substitute::Rules replacement_rules;
 
 	}
 

--- a/core/pythoncdb/py_algorithms.cc
+++ b/core/pythoncdb/py_algorithms.cc
@@ -130,7 +130,7 @@ namespace cadabra {
 		def_algo<factor_in, Ex>(m, "factor_in", true, false, 0, py::arg("factors"));
 		def_algo<factor_out, Ex, bool>(m, "factor_out", true, false, 0, py::arg("factors"), py::arg("right") = false);
 		def_algo<fierz, Ex>(m, "fierz", true, false, 0, py::arg("spinors"));
-		def_algo<substitute, Ex, bool>(m, "substitute", true, false, 0, py::arg("rules"), py::arg("partial") = true);
+		def_algo<substitute, Ex&, bool>(m, "substitute", true, false, 0, py::arg("rules"), py::arg("partial") = true);
 		def_algo<take_match, Ex>(m, "take_match", true, false, 0, py::arg("rules"));
 		def_algo<replace_match>(m, "replace_match", false, false, 0);
 		def_algo<zoom, Ex, bool>(m, "zoom", true, false, 0, py::arg("rules"), py::arg("partial") = true);


### PR DESCRIPTION
This addresses an issue discussed in
https://cadabra.science/qa/2643/efficiency-in-python-vs-cadabra-for-long-substitution-rules

***
NOTE: The version of substitute in master does not pass the rules (`args`) by reference. It makes a copy instead. I changed that as well as adding the mentioned functionality.
***

This modifies how `substitute` behaves to remember if the substitution rules have already been processed and checked for consistency.  So far as I can tell, aside from throwing exceptions, the pre-processing in substitute only stores in `lhs_contains_dummies` and `rhs_contains_dummies` boolean conditions for each substitution rule. These need to be cached in between substitute calls and recalled when we skip the pre-processing.

This is done by adding a `substitute::Rules` subclass, and creating a global instance of this subclass in the `cadabra` namespace.  The rules `args` are stored as a `weak_ptr` in a map when first encountered, along with the results for *_contains_dummies. In order to track if `args` have been modified by the user in between calls, the flag on the `Ex` object is set to `l_checkpointed` when first stored. Any user alterations should modify this flag. If it ever changes, the rule will be dropped and reprocessed.

When the number of rules has grown beyond a threshold, a cleanup routine is called that eliminates expired `weak_ptr`s and rules that have been modified.

This initial version has a fixed number of rules that may be stored (`max_size` = 1000), but if this proves useful, it could be modified to only keep more  recent rules.

