### PR TITLE
Fixed two small typos in substitute.cc

### DIFF
--- a/core/algorithms/substitute.cc
+++ b/core/algorithms/substitute.cc
@@ -511,12 +511,12 @@ bool substitute::Rules::is_present(Ex& rules) const
 		bool rule_found = (rule_it != properties.end());
 		if (!rule_found) return false;
 		
-		// rules should have l_checkpointed set
+		// rules should have l_cached set
 		bool rule_unchanged = (rules.state() == result_t::l_cached);
 		
 		// If rule has been changed, erase  it.
 		if (!rule_unchanged) {
-			properties.erase(rules_it);
+			properties.erase(rule_it);
 			return false;
 			} 
 		else {
@@ -541,7 +541,7 @@ void substitute::Rules::cleanup()
 		if (it->first.expired()) {
 			it = properties.erase(it);
 			} 
-		else if (it->first.lock()->state() != result_t::l_checkpointed) {
+		else if (it->first.lock()->state() != result_t::l_cached) {
 			it = properties.erase(it);
 			}
 		else {


### PR DESCRIPTION
1) Replaced one occurrence of `rules_it` with `rule_it` (already fixed in `devel`).
2) One occurrence of `l_checkpointed` should be `l_cached` (I believe).
3) Changed comment to refer to `l_cached` instead of `l_checkpointed`.