### PR TITLE
Updated substitute to use LRUcache for rules.

### DIFF
--- a/core/Storage.cc
+++ b/core/Storage.cc
@@ -122,6 +122,9 @@ namespace cadabra {
 				if(state_!=Ex::result_t::l_error)
 					state_=newstate;
 				break;
+			case Ex::result_t::l_cached:
+				state_=newstate;
+				break;
 			default:
 				break;
 			}

--- a/core/algorithms/substitute.cc
+++ b/core/algorithms/substitute.cc
@@ -474,13 +474,9 @@ void substitute::Rules::store(Ex& rules,
 				}
 			}
 
-		// If we're too big, don't add anything else.
-		if (properties.size() >= max_size) {
-			return;
-			}
-		
 		std::weak_ptr<Ex> rules_ptr = rules.shared_from_this();
-		properties[rules_ptr] = { lhs_contains_dummies, rhs_contains_dummies };
+		// properties[rules_ptr] = { lhs_contains_dummies, rhs_contains_dummies };'
+		properties.insert(rules_ptr, { lhs_contains_dummies, rhs_contains_dummies });
 		// Mark this expression as cached; any change will remove that state
 		// and ensure that we do not use the cached expression later.
 		rules.update_state(result_t::l_cached);
@@ -514,7 +510,7 @@ bool substitute::Rules::is_present(Ex& rules) const
 		// rules should have l_cached set
 		bool rule_unchanged = (rules.state() == result_t::l_cached);
 		
-		// If rule has been changed, erase  it.
+		// If rule has been changed, erase it.
 		if (!rule_unchanged) {
 			properties.erase(rule_it);
 			return false;

--- a/core/algorithms/substitute.hh
+++ b/core/algorithms/substitute.hh
@@ -3,6 +3,7 @@
 
 #include "Algorithm.hh"
 #include "algorithms/sort_product.hh"
+#include "lru_cache.hh"
 
 namespace cadabra {
 
@@ -53,7 +54,11 @@ namespace cadabra {
 			// rules to avoid processing them in subsequent calls.
 
 			class Rules {
+
 				public:
+					Rules(size_t max_size_=1000, size_t cleanup_threshold_=100) 
+						: properties(max_size_), max_size(max_size_), cleanup_threshold(cleanup_threshold_) {}
+
 					// Associate rule properties with a specific object
 					void store(Ex& rules,
 								  std::map<iterator, bool>& lhs_contains_dummies,
@@ -75,22 +80,25 @@ namespace cadabra {
 
 				private:
 					// Map storing weak pointers to `Ex` and pairs of lhs/rhs maps as values
-					mutable std::map<std::weak_ptr<Ex>, 
-								std::pair<std::map<iterator, bool>, std::map<iterator, bool>>, 
-								std::owner_less<std::weak_ptr<Ex>>> properties;
-
+					mutable LRUcache<std::weak_ptr<Ex>, 
+										std::pair< std::map<iterator, bool>, std::map<iterator, bool> >,
+										std::owner_less<std::weak_ptr<Ex>>
+										> properties;
+					// Max size of the rules list
+					size_t max_size;
 					// Initial size threshold to trigger cleanup_rules
-					unsigned int cleanup_threshold = 100;
-					// Store max size of the rules list to avoid it getting out of hand
-					unsigned int max_size = 1000;
+					size_t cleanup_threshold;
+
+
 				};
 
 			// Shared instance of all replacement rules.
-			static Rules    replacement_rules;
+			public:
+				static Rules    replacement_rules;
 			
 	};
 
 
 	}
 
-	
+

--- a/core/lru_cache.hh
+++ b/core/lru_cache.hh
@@ -7,7 +7,7 @@
 /** \mainpage lru_cache.hh
     \author   Daniel Butter
     \version  1.00
-    \date     2024-11-13
+    \date     2024-11-15
     \see      http://github.com/dpbutter/lru_cache.hh/
 
 */
@@ -59,11 +59,11 @@ public:
             touch(lookup_it->second);
             lookup_it->second->second = value;
         } else {
-            while (cache_list.size() >= max_size) {
-                evict();
-            }
             cache_list.emplace_front(key, value);
             cache_lookup[key] = cache_list.begin();
+            while (cache_list.size() > max_size) {
+                evict();
+            }
         }
     }
 
@@ -75,13 +75,13 @@ public:
             touch(lookup_it->second);
             return lookup_it->second->second;
         } else {
-            while (cache_list.size() >= max_size) {
-                evict();
-            }
             // Create new entry, inserting at the front of the list
             cache_list.emplace_front(key, Value());
             iterator new_iter = cache_list.begin();
             cache_lookup[key] = new_iter;
+            while (cache_list.size() > max_size) {
+                evict();
+            }
             return new_iter->second;
         }
     }
@@ -145,7 +145,7 @@ public:
     // Resize the cache
     void resize(size_t new_size) {
         max_size = new_size;
-        while (cache_list.size() >= max_size) {
+        while (cache_list.size() > max_size) {
             evict();
         }
     }

--- a/core/lru_cache.hh
+++ b/core/lru_cache.hh
@@ -1,0 +1,172 @@
+//	STL-like templated LRU cache.
+//
+// Copyright (C) 2024 Daniel Butter <dbutter@gmail.com>
+// Distributed under the MIT license.
+//
+
+/** \mainpage lru_cache.hh
+    \author   Daniel Butter
+    \version  1.00
+    \date     2024-11-13
+    \see      http://github.com/dpbutter/lru_cache.hh/
+
+*/
+
+
+#ifndef lru_cache_hh_
+#define lru_cache_hh_
+
+#include <map>
+#include <list>
+#include <stdexcept>
+#include <iterator>
+
+template <typename Key, typename Value, typename Compare = std::less<Key>>
+class LRUcache {
+public:
+    using value_type = std::pair<Key, Value>;
+    using List = std::list<value_type>;
+    using iterator = typename List::iterator;
+    using const_iterator = typename List::const_iterator;
+    using size_type = size_t;
+
+
+    LRUcache(size_t capacity) : max_size(capacity) {}
+
+    // Touches a list iterator, moving it to the top
+    void touch(iterator& it) { 
+        if (it != cache_list.begin()) {
+            cache_list.splice(cache_list.begin(), cache_list, it);
+        }
+    }
+
+    // Access an item by key (possibly touching it)
+    Value& at(const Key& key, bool touching = true) {
+        auto lookup_it = cache_lookup.find(key);
+        if (lookup_it == cache_lookup.end()) {
+            throw std::out_of_range("Key not found");
+        }
+        if (touching) {
+            touch(lookup_it->second);
+        }
+        return lookup_it->second->second;
+    }
+
+    // Insert or update an item (always touches)
+    void insert(const Key& key, const Value& value) {
+        auto lookup_it = cache_lookup.find(key);
+        if (lookup_it != cache_lookup.end()) {
+            touch(lookup_it->second);
+            lookup_it->second->second = value;
+        } else {
+            while (cache_list.size() >= max_size) {
+                evict();
+            }
+            cache_list.emplace_front(key, value);
+            cache_lookup[key] = cache_list.begin();
+        }
+    }
+
+    // Access an item (or create it) using operator[] (always touches)
+    Value& operator[](const Key& key) {
+        auto lookup_it = cache_lookup.find(key);
+        if (lookup_it != cache_lookup.end()) {
+            // If found, move it to the front of the list (LRU behavior)
+            touch(lookup_it->second);
+            return lookup_it->second->second;
+        } else {
+            while (cache_list.size() >= max_size) {
+                evict();
+            }
+            // Create new entry, inserting at the front of the list
+            cache_list.emplace_front(key, Value());
+            iterator new_iter = cache_list.begin();
+            cache_lookup[key] = new_iter;
+            return new_iter->second;
+        }
+    }
+
+    // Find a key (possibly touching it)
+    iterator find(const Key& key, bool touching = true) {
+        auto lookup_it = cache_lookup.find(key);
+        if (lookup_it == cache_lookup.end()) {
+            return cache_list.end();  // Key not found
+        }
+        if (touching) {
+            touch(lookup_it->second);
+        }
+        return lookup_it->second;
+    }
+
+    // Check if a key exists (possibly touching it)
+    bool contains(const Key& key, bool touching = true) {
+        return find(key, touching) != end();
+    }
+
+    // Remove an item by key
+    size_t erase(const Key& key) {
+        auto lookup_it = cache_lookup.find(key);
+        if (lookup_it != cache_lookup.end()) {
+            cache_list.erase(lookup_it->second);
+            cache_lookup.erase(lookup_it);
+            return 1;
+        }
+        return 0;
+    }
+
+    // Remove an item by iterator
+    iterator erase(const_iterator& it) {
+        cache_lookup.erase(it->first);
+        return cache_list.erase(it);
+    }
+    iterator erase(iterator& it) {
+        cache_lookup.erase(it->first);
+        return cache_list.erase(it);
+    }
+
+
+    // Clear the cache
+    void clear() {
+        cache_list.clear();
+        cache_lookup.clear();
+    }
+
+    // Check if the cache is empty
+    bool empty() const {
+        return cache_list.empty();
+    }
+
+    // Get the current size of the cache
+    size_t size() const {
+        assert(cache_list.size() == cache_lookup.size());
+        return cache_list.size();
+    }
+
+    // Resize the cache
+    void resize(size_t new_size) {
+        max_size = new_size;
+        while (cache_list.size() >= max_size) {
+            evict();
+        }
+    }
+
+    // Iterators
+    iterator begin() { return cache_list.begin(); }
+    iterator end() { return cache_list.end(); }
+
+
+private:
+
+    List cache_list;  							        // Doubly linked list of key-value pairs
+    std::map<Key, iterator, Compare> cache_lookup;      // Map to locate list nodes
+    size_t max_size;
+
+    void evict() {
+        auto lru = cache_list.back().first;
+        cache_lookup.erase(lru);
+        cache_list.pop_back();
+    }
+};
+
+
+#endif

--- a/core/pythoncdb/py_algorithms.cc
+++ b/core/pythoncdb/py_algorithms.cc
@@ -162,5 +162,9 @@ namespace cadabra {
 
 				}
 				);
+		
+		m.def("get_num_rules", []() {
+			return substitute::replacement_rules.size();
+			});
 		}
 	}


### PR DESCRIPTION
This is an attempt to convert the rule cache in `substitute` into an LRU cache, so that more recently used rules are kept alive.

I wanted a drop-in replacement for `std::map` in the `substitute` code so that I didn't have to pollute `substitute` with the LRU code. Most solutions I found online use `std::unordered_map` for the hash, but this wouldn't work well with weak pointers, so I wrote `lru_cache.hh`.  The keys and values are stored in a linked list, and a map connects the keys to list iterators. The public interface is intended to be mostly identical to `std::map`.

Note: Ignore `Storage.hh` (now fixed in `devel`) and `py_algorithms.cc` (which was for debugging purposes; might be useful to keep but with a better name).