### PR TITLE
Associate window with GtkApplication.

### DIFF
--- a/frontend/gtkmm/NotebookWindow.cc
+++ b/frontend/gtkmm/NotebookWindow.cc
@@ -66,6 +66,8 @@ NotebookWindow::NotebookWindow(Cadabra *c, bool ro)
 	dispatch_tex_error.connect(sigc::mem_fun(*this, &NotebookWindow::handle_thread_tex_error));
 	dispatch_update_status.connect(sigc::mem_fun(*this, &NotebookWindow::update_status));
 
+	// Associate with application
+	c->add_window(*this);
 	// Set the window icon.
 	set_default_icon_name("cadabra2-gtk");
 	set_icon_name("cadabra2-gtk");


### PR DESCRIPTION
When a NotebookWindow is created, it is not mapped to the Cadabra GtkApplication. This causes window managers to fail to track windows by the app name, leading to issues such as a generic icon showing instead of the cadabra app icon (for example on GNOME shell) and multiple cadabra windows showing up on the dash bar without being grouped by application. Fixed by this commit by calling
`GtkApplication::add_window` in the NotebookWindow constructor.