### PR TITLE
Prop enhacements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
     endif()
   endif()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O1 -Wall -Wextra -Wunused -Wno-psabi -Wno-unknown-pragmas -Wno-misleading-indentation -fvisibility=hidden -Wno-unused-but-set-variable -Wno-unused-parameter -fno-omit-frame-pointer")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O2 -Wall -Wextra -Wunused -Wno-psabi -Wno-unknown-pragmas -Wno-misleading-indentation -fvisibility=hidden -Wno-unused-but-set-variable -Wno-unused-parameter")
 endif()
 
 # Clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
     endif()
   endif()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O2 -Wall -Wextra -Wunused -Wno-psabi -Wno-unknown-pragmas -Wno-misleading-indentation -fvisibility=hidden -Wno-unused-but-set-variable -Wno-unused-parameter")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O1 -Wall -Wextra -Wunused -Wno-psabi -Wno-unknown-pragmas -Wno-misleading-indentation -fvisibility=hidden -Wno-unused-but-set-variable -Wno-unused-parameter -fno-omit-frame-pointer")
 endif()
 
 # Clang

--- a/core/Compare.cc
+++ b/core/Compare.cc
@@ -320,7 +320,7 @@ namespace cadabra {
 		// 
 		// if(!i1.is_valid() && !i2.is_valid())
 		// 	return match_t::subtree_match;
-		
+
 		DEBUGLN( std::cerr << tab() << "equal_subtree with use_props = " << use_props << std::endl; );
 		++offset;
 

--- a/core/IndexClassifier.cc
+++ b/core/IndexClassifier.cc
@@ -490,57 +490,60 @@ Ex IndexClassifier::get_dummy(const list_property *dums,
                               const index_map_t * four,
                               const index_map_t * five) const
 	{
-	std::pair<Properties::pattern_map_t::const_iterator, Properties::pattern_map_t::const_iterator>
-	pr=kernel.properties.pats.equal_range(dums);
+	auto pats_it = kernel.properties.pats_dict.find(typeid(*dums));
+	if (pats_it != kernel.properties.pats_dict.end()) {
+		Properties::pattern_map_t pats = pats_it->second;
+		std::pair<Properties::pattern_map_t::const_iterator, Properties::pattern_map_t::const_iterator> pr=pats.equal_range(dums);
 
-	// std::cerr << "finding index not in: " << std::endl;
-	// if(one)
-	// 	for(auto& i: *one)
-	// 		std::cerr << i.first << std::endl;
-	// if(two)
-	// 	for(auto& i: *two)
-	// 		std::cerr << i.first << std::endl;
-	// if(three)
-	// 	for(auto& i: *three)
-	// 		std::cerr << i.first << std::endl;
-	// if(four)
-	// 	for(auto& i: *four)
-	// 		std::cerr << i.first << std::endl;
-	// if(five)
-	// 	for(auto& i: *five)
-	// 		std::cerr << i.first << std::endl;
+		// std::cerr << "finding index not in: " << std::endl;
+		// if(one)
+		// 	for(auto& i: *one)
+		// 		std::cerr << i.first << std::endl;
+		// if(two)
+		// 	for(auto& i: *two)
+		// 		std::cerr << i.first << std::endl;
+		// if(three)
+		// 	for(auto& i: *three)
+		// 		std::cerr << i.first << std::endl;
+		// if(four)
+		// 	for(auto& i: *four)
+		// 		std::cerr << i.first << std::endl;
+		// if(five)
+		// 	for(auto& i: *five)
+		// 		std::cerr << i.first << std::endl;
 
-	while(pr.first!=pr.second) {
-		// std::cerr << "trying: " << std::endl;
+		while(pr.first!=pr.second) {
+			// std::cerr << "trying: " << std::endl;
 		// std::cerr << pr.first->second->obj << std::endl;
-		if(pr.first->second->obj.begin()->is_autodeclare_wildcard()) {
+			if(pr.first->second->obj.begin()->is_autodeclare_wildcard()) {
 			// std::cerr << "is autodeclare wildcard" << std::endl;
-			std::string base=*pr.first->second->obj.begin()->name_only();
-			int used=max_numbered_name(base, one, two, three, four, five);
-			std::ostringstream str;
-			str << base << used+1;
-			//			txtout << "going to use " << str.str() << std::endl;
-			nset_t::iterator newnm=name_set.insert(str.str()).first;
-			Ex ret;
-			ret.set_head(str_node(newnm));
-			return ret;
-			}
-		else {
-			// std::cerr << "is NOT autodeclare" << std::endl;
-			const Ex& inm=(*pr.first).second->obj;
-			// BUG: even if only _{a} is in the used map, we should not
-			// accept ^{a}. But since ...
-			if(index_in_set(inm, one)==false   &&
-			      index_in_set(inm, two)==false   &&
-			      index_in_set(inm, three)==false &&
-			      index_in_set(inm, four)==false  &&
-			      index_in_set(inm, five)==false) {
-				// std::cerr << "ok to use " << inm << std::endl;
-				return inm;
+				std::string base=*pr.first->second->obj.begin()->name_only();
+				int used=max_numbered_name(base, one, two, three, four, five);
+				std::ostringstream str;
+				str << base << used+1;
+				//			txtout << "going to use " << str.str() << std::endl;
+				nset_t::iterator newnm=name_set.insert(str.str()).first;
+				Ex ret;
+				ret.set_head(str_node(newnm));
+				return ret;
 				}
+			else {
+			// std::cerr << "is NOT autodeclare" << std::endl;
+				const Ex& inm=(*pr.first).second->obj;
+				// BUG: even if only _{a} is in the used map, we should not
+				// accept ^{a}. But since ...
+				if(index_in_set(inm, one)==false   &&
+					index_in_set(inm, two)==false   &&
+					index_in_set(inm, three)==false &&
+					index_in_set(inm, four)==false  &&
+					index_in_set(inm, five)==false) {
+					// std::cerr << "ok to use " << inm << std::endl;
+					return inm;
+					}
+				}
+			++pr.first;
 			}
-		++pr.first;
-		}
+	}
 
 	const Indices *dd=dynamic_cast<const Indices *>(dums);
 	assert(dd);

--- a/core/IndexClassifier.cc
+++ b/core/IndexClassifier.cc
@@ -490,7 +490,8 @@ Ex IndexClassifier::get_dummy(const list_property *dums,
                               const index_map_t * four,
                               const index_map_t * five) const
 	{
-	auto pats_it = kernel.properties.pats_dict.find(typeid(*dums));
+	std::type_index type_idx = std::type_index(typeid(*dums));
+	auto pats_it = kernel.properties.pats_dict.find(type_idx);
 	if (pats_it != kernel.properties.pats_dict.end()) {
 		Properties::pattern_map_t pats = pats_it->second;
 		std::pair<Properties::pattern_map_t::const_iterator, Properties::pattern_map_t::const_iterator> pr=pats.equal_range(dums);

--- a/core/IndexClassifier.cc
+++ b/core/IndexClassifier.cc
@@ -490,61 +490,56 @@ Ex IndexClassifier::get_dummy(const list_property *dums,
                               const index_map_t * four,
                               const index_map_t * five) const
 	{
-	std::type_index type_idx = std::type_index(typeid(*dums));
-	auto pats_it = kernel.properties.pats_dict.find(type_idx);
-	if (pats_it != kernel.properties.pats_dict.end()) {
-		Properties::propmap_t pats = pats_it->second;
-		std::pair<Properties::propmap_t::const_iterator, Properties::propmap_t::const_iterator> pr=pats.equal_range(dums);
+	std::pair<Properties::const_iterator, Properties::const_iterator> pr=kernel.properties.equal_range(dums);
 
-		// std::cerr << "finding index not in: " << std::endl;
-		// if(one)
-		// 	for(auto& i: *one)
-		// 		std::cerr << i.first << std::endl;
-		// if(two)
-		// 	for(auto& i: *two)
-		// 		std::cerr << i.first << std::endl;
-		// if(three)
-		// 	for(auto& i: *three)
-		// 		std::cerr << i.first << std::endl;
-		// if(four)
-		// 	for(auto& i: *four)
-		// 		std::cerr << i.first << std::endl;
-		// if(five)
-		// 	for(auto& i: *five)
-		// 		std::cerr << i.first << std::endl;
+	// std::cerr << "finding index not in: " << std::endl;
+	// if(one)
+	// 	for(auto& i: *one)
+	// 		std::cerr << i.first << std::endl;
+	// if(two)
+	// 	for(auto& i: *two)
+	// 		std::cerr << i.first << std::endl;
+	// if(three)
+	// 	for(auto& i: *three)
+	// 		std::cerr << i.first << std::endl;
+	// if(four)
+	// 	for(auto& i: *four)
+	// 		std::cerr << i.first << std::endl;
+	// if(five)
+	// 	for(auto& i: *five)
+	// 		std::cerr << i.first << std::endl;
 
-		while(pr.first!=pr.second) {
-			// std::cerr << "trying: " << std::endl;
-		// std::cerr << pr.first->second->obj << std::endl;
-			if(pr.first->second->obj.begin()->is_autodeclare_wildcard()) {
-			// std::cerr << "is autodeclare wildcard" << std::endl;
-				std::string base=*pr.first->second->obj.begin()->name_only();
-				int used=max_numbered_name(base, one, two, three, four, five);
-				std::ostringstream str;
-				str << base << used+1;
-				//			txtout << "going to use " << str.str() << std::endl;
-				nset_t::iterator newnm=name_set.insert(str.str()).first;
-				Ex ret;
-				ret.set_head(str_node(newnm));
-				return ret;
-				}
-			else {
-			// std::cerr << "is NOT autodeclare" << std::endl;
-				const Ex& inm=(*pr.first).second->obj;
-				// BUG: even if only _{a} is in the used map, we should not
-				// accept ^{a}. But since ...
-				if(index_in_set(inm, one)==false   &&
-					index_in_set(inm, two)==false   &&
-					index_in_set(inm, three)==false &&
-					index_in_set(inm, four)==false  &&
-					index_in_set(inm, five)==false) {
-					// std::cerr << "ok to use " << inm << std::endl;
-					return inm;
-					}
-				}
-			++pr.first;
+	while(pr.first!=pr.second) {
+		// std::cerr << "trying: " << std::endl;
+	// std::cerr << pr.first->second->obj << std::endl;
+		if(pr.first->second->obj.begin()->is_autodeclare_wildcard()) {
+		// std::cerr << "is autodeclare wildcard" << std::endl;
+			std::string base=*pr.first->second->obj.begin()->name_only();
+			int used=max_numbered_name(base, one, two, three, four, five);
+			std::ostringstream str;
+			str << base << used+1;
+			//			txtout << "going to use " << str.str() << std::endl;
+			nset_t::iterator newnm=name_set.insert(str.str()).first;
+			Ex ret;
+			ret.set_head(str_node(newnm));
+			return ret;
 			}
-	}
+		else {
+		// std::cerr << "is NOT autodeclare" << std::endl;
+			const Ex& inm=(*pr.first).second->obj;
+			// BUG: even if only _{a} is in the used map, we should not
+			// accept ^{a}. But since ...
+			if(index_in_set(inm, one)==false   &&
+				index_in_set(inm, two)==false   &&
+				index_in_set(inm, three)==false &&
+				index_in_set(inm, four)==false  &&
+				index_in_set(inm, five)==false) {
+				// std::cerr << "ok to use " << inm << std::endl;
+				return inm;
+				}
+			}
+		++pr.first;
+		}
 
 	const Indices *dd=dynamic_cast<const Indices *>(dums);
 	assert(dd);

--- a/core/IndexClassifier.cc
+++ b/core/IndexClassifier.cc
@@ -550,7 +550,6 @@ Ex IndexClassifier::get_dummy(const list_property *dums,
 	assert(dd);
 	throw ConsistencyException("Ran out of dummy indices for type \""+dd->set_name+"\".");
 	}
-	}
 
 Ex IndexClassifier::get_dummy(const list_property *dums, Ex::iterator it) const
 	{

--- a/core/IndexClassifier.cc
+++ b/core/IndexClassifier.cc
@@ -550,6 +550,7 @@ Ex IndexClassifier::get_dummy(const list_property *dums,
 	assert(dd);
 	throw ConsistencyException("Ran out of dummy indices for type \""+dd->set_name+"\".");
 	}
+	}
 
 Ex IndexClassifier::get_dummy(const list_property *dums, Ex::iterator it) const
 	{

--- a/core/IndexClassifier.cc
+++ b/core/IndexClassifier.cc
@@ -493,8 +493,8 @@ Ex IndexClassifier::get_dummy(const list_property *dums,
 	std::type_index type_idx = std::type_index(typeid(*dums));
 	auto pats_it = kernel.properties.pats_dict.find(type_idx);
 	if (pats_it != kernel.properties.pats_dict.end()) {
-		Properties::pattern_map_t pats = pats_it->second;
-		std::pair<Properties::pattern_map_t::const_iterator, Properties::pattern_map_t::const_iterator> pr=pats.equal_range(dums);
+		Properties::propmap_t pats = pats_it->second;
+		std::pair<Properties::propmap_t::const_iterator, Properties::propmap_t::const_iterator> pr=pats.equal_range(dums);
 
 		// std::cerr << "finding index not in: " << std::endl;
 		// if(one)

--- a/core/Kernel.cc
+++ b/core/Kernel.cc
@@ -112,7 +112,7 @@ Kernel::~Kernel()
 	//	std::cerr << "~Kernel() " << this << std::endl;
 	}
 
-void Kernel::inject_property(property *prop, std::shared_ptr<Ex> ex, std::shared_ptr<Ex> param)
+const property* Kernel::inject_property(property *prop, std::shared_ptr<Ex> ex, std::shared_ptr<Ex> param)
 	{
 	Ex::iterator it=ex->begin();
 
@@ -124,7 +124,7 @@ void Kernel::inject_property(property *prop, std::shared_ptr<Ex> ex, std::shared
 		}
 	// Validate and insert a copy of the property.
 	prop->validate(*this, ex);
-	properties.master_insert(Ex(it), prop);
+	return properties.master_insert(Ex(it), prop);
 	}
 
 std::shared_ptr<cadabra::Ex> Kernel::ex_from_string(const std::string& s)

--- a/core/Kernel.hh
+++ b/core/Kernel.hh
@@ -20,7 +20,7 @@ namespace cadabra {
 
 			/// Inject a property into the system and attach it to the given pattern.
 			/// Transfers property ownership to the kernel.
-			void inject_property(property *prop, std::shared_ptr<Ex> pattern, std::shared_ptr<Ex> property_arguments);
+			const property* inject_property(property *prop, std::shared_ptr<Ex> pattern, std::shared_ptr<Ex> property_arguments);
 
 			/// Create an Ex expression object from a string, which will be parsed.
 			std::shared_ptr<Ex> ex_from_string(const std::string&);

--- a/core/Props.cc
+++ b/core/Props.cc
@@ -401,9 +401,8 @@ void Properties::insert_prop(const Ex& et, const property *pr) {
 
 	// Make sure there is no existing property of the same type matching pat
 	auto walk = begin(pat->obj.begin()->name_only());
-	auto end_it = end(pat->obj.begin()->name_only());
 
-	while (walk != end_it) {
+	while (walk != end(pat->obj.begin()->name_only())) {
 		if (typeid(*walk->first) != typeid(*pr)) {
 			walk.next_proptype();
 			continue;

--- a/core/Props.cc
+++ b/core/Props.cc
@@ -180,6 +180,7 @@ Properties::registered_property_map_t::~registered_property_map_t()
 template<typename T>
 void Properties::registered_property_map_t::register_type() {
 	T obj;
+	// obj is an actual property object (e.g. AntiCommuting) and not a pointer
 	std::type_index typeidx = typeid(obj);
 	auto it = types_to_names_.find(typeidx);
 	if (it == types_to_names_.end()) {
@@ -188,13 +189,12 @@ void Properties::registered_property_map_t::register_type() {
 	}
 }
 
-template<typename T>
-void Properties::registered_property_map_t::register_type(const T& obj) {
-	std::type_index typeidx(typeid(obj));
+void Properties::registered_property_map_t::register_type(const property* prop) {
+	std::type_index typeidx(typeid(*prop));
 	auto it = types_to_names_.find(typeidx);
 	if (it == types_to_names_.end()) {
-		types_to_names_[typeidx] = obj.name();
-		names_to_types_.insert({obj.name(),typeidx});
+		types_to_names_[typeidx] = prop->name();
+		names_to_types_.insert({prop->name(),typeidx});
 	}
 }
 
@@ -210,10 +210,9 @@ void Properties::register_property_type()
 	registered_properties.register_type<T>();
 	}
 
-template<typename T>
-void Properties::register_property_type(const T& obj)
+void Properties::register_property_type(const property* prop)
 	{
-	registered_properties.register_type(obj);
+	registered_properties.register_type(prop);
 	}
 
 keyval_t::const_iterator keyval_t::find(const std::string& key) const
@@ -757,7 +756,7 @@ void Properties::dict_erase_(const property* prop, pattern* pat) {
 
 // Insert a property and pattern into the dict_maps
 void Properties::dict_insert_(const property* prop, pattern* pat) {
-	register_property_type(*prop);
+	register_property_type(prop);
 	std::type_index type_idx = typeid(*prop);
 	auto name = pat->obj.begin()->name_only();
 	props_dict[name].emplace( type_idx, std::make_pair(pat,prop));

--- a/core/Props.cc
+++ b/core/Props.cc
@@ -402,7 +402,7 @@ void Properties::insert_prop(const Ex& et, const property *pr) {
 	// Make sure there is no existing property of the same type matching pat
 	auto walk = begin(pat->obj.begin()->name_only());
 
-	while (walk != end(pat->obj.begin()->name_only())) {
+	while (walk != end()) {
 		if (typeid(*walk->first) != typeid(*pr)) {
 			walk.next_proptype();
 			continue;

--- a/core/Props.cc
+++ b/core/Props.cc
@@ -559,7 +559,7 @@ void Properties::insert_list_prop(const std::vector<Ex>& its, const list_propert
 	{
 	assert(its.size()>0);
 	
-	auto pats = pats_dict[typeid(*pr)];
+	auto& pats = pats_dict[typeid(*pr)];
 	assert(pats.find(pr)==pats.end()); // identical properties have to be assigned through insert_list_prop
 
 	/* Description of below code

--- a/core/Props.cc
+++ b/core/Props.cc
@@ -167,8 +167,8 @@ bool Properties::has(const property *pb, Ex::iterator it)
 void Properties::clear()
 	{
 	// Clear and free the property lists. Since pointers to properties can
-	// be shared, we use the pats_dict map and make sure that we only free each
-	// property* pointer once.
+	// be shared (but patterns cannot yet), we use the pats_dict map and make 
+	// sure that we only free each property* pointer once.
 
 	for (const auto& [_, this_pats] : pats_dict) {
 		auto it=this_pats.begin();
@@ -615,7 +615,7 @@ const list_property* Properties::insert_list_prop(const std::vector<Ex>& its, co
 		if (match_type == list_property::exact_match) {
 			delete pr;
 			pr=static_cast<const list_property *>( (*pit).first );
-			// Because pr is passed by reference, the caller maintains a valid pointer.
+			// Later we return the new pr to the caller so they have a valid pointer.
 			break;
 		} else if (match_type == list_property::id_match) {
 			erase((*pit).first);

--- a/core/Props.hh
+++ b/core/Props.hh
@@ -309,7 +309,7 @@ namespace cadabra {
 			/// Register a property for the indicated Ex. Takes both normal and list
 			/// properties and works out which insert calls to make. The property ownership
 			/// is transferred to us on using this call.
-			std::string master_insert(Ex proptree, const property *thepropbase);
+			const property* master_insert(Ex proptree, const property *thepropbase);
 
 			void        clear();
 
@@ -394,13 +394,16 @@ namespace cadabra {
 			/// Erases pattern from a given property, leaving other patterns alone.
 			void erase(const property*, pattern*);
 
+			/// Helper function to lookup all patterns associated with a property.
+			/// If the property is invalid, it returns a null pointer in the first slot.
+			std::pair<const property*, std::vector<const pattern*> > lookup_property(const property*) const;
 
 		private:
 			// Insert a property. Do not use this directly, use the public
 			// interface `master_insert` instead.
 			void insert_prop(const Ex&, const property *);
 			void insert_prop_old(const Ex&, const property *);
-			void insert_list_prop(const std::vector<Ex>&, const list_property *&);
+			const list_property* insert_list_prop(const std::vector<Ex>&, const list_property *);
 			bool check_label(const property *, const std::string&) const;
 			bool check_label(const labelled_property *, const std::string&) const;			
 			// Search through pointers

--- a/core/Props.hh
+++ b/core/Props.hh
@@ -28,7 +28,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <type_traits>
 #include "Storage.hh"
 #include <typeindex>
-		
+#include <iterator>
+#include <functional>
+
 namespace cadabra {
 
 	class Properties;
@@ -331,15 +333,149 @@ namespace cadabra {
 			 * pats_dict groups the properties in pats by their property_type. This allows us to
 			 * iterate over e.g. all AntiCommuting patterns directly.
 			 **************************************************************************************/
-
-			typedef std::map<nset_t::iterator, 
-							 std::map<std::type_index, std::vector<pat_prop_pair_t>>, 
-							 nset_it_less>   													property_dictmap_t;
-			typedef std::map<std::type_index,  
-							 std::multimap<const property *, pattern *>>                     	pattern_dictmap_t;
+			typedef std::map<std::type_index, std::vector<pat_prop_pair_t>>				   pat_prop_typemap_t;
+			typedef std::map<nset_t::iterator, pat_prop_typemap_t, nset_it_less>           property_dictmap_t;
+			typedef std::map<std::type_index, std::multimap<const property *, pattern *>>  pattern_dictmap_t;
 
 			property_dictmap_t  props_dict;  // pattern -> map(property_type, pat_prop_pairs)
 			pattern_dictmap_t   pats_dict;   // property_type -> multimap(property, pattern)
+			
+			/// Specialized property iterator for iterating over properties in a pat_prop_typemap_t that match a condition
+			class PropertyIterator {
+
+				using iterator_category = std::bidirectional_iterator_tag;
+				using difference_type   = std::ptrdiff_t;
+				using value_type        = pat_prop_pair_t;
+				using pointer           = value_type*;
+				using reference         = value_type&;
+
+				using InnerIter = typename std::vector<pat_prop_pair_t>::iterator;
+				using OuterIter  = typename pat_prop_typemap_t::iterator;
+
+				public:
+					PropertyIterator(pat_prop_typemap_t& m, std::function<bool(const std::type_index&)> condition, bool is_end = false) : typemap_(m), condition_(condition) {
+						if (is_end) {
+							outer_it_ = typemap_.end();
+							inner_it_ = InnerIter();
+						} else {
+							outer_it_ = typemap_.begin();
+							skip_ahead();
+						}
+					}
+
+					PropertyIterator& operator++() {
+						++inner_it_;
+						if (inner_it_ == outer_it_->second.end()) {
+							++outer_it_;
+							skip_ahead();
+						}
+						return *this;
+					}
+
+					PropertyIterator& operator--() {
+						if (outer_it_ == typemap_.end()) { // End() to last element
+							--outer_it_;
+							skip_back();
+						}
+						if (inner_it_ == outer_it_->second.begin()) {
+							--outer_it_;
+							skip_back();
+						}
+						--inner_it_;
+						return *this;
+					}
+
+					reference operator*() const { return *inner_it_; }
+    				pointer operator->() const { return &(*inner_it_); }
+
+				private:
+					pat_prop_typemap_t& typemap_;
+					std::function<bool(const std::type_index&)> condition_;
+					OuterIter outer_it_;
+					InnerIter inner_it_;
+
+					// Skip ahead to the next property class if needed
+					void skip_ahead() {
+						while (outer_it_ != typemap_.end()) {
+							if (condition_(outer_it_->first)) {
+								inner_it_ = outer_it_->second.begin();
+								if (inner_it_ != outer_it_->second.end()) return;
+							}
+							++outer_it_;
+						}
+						// At end, so inner_it_ is blank.
+						inner_it_ = InnerIter();
+					}
+					
+					// Skip back to the previous class if needed
+					void skip_back() {
+						while (outer_it_ != typemap_.begin()) {
+							if (condition_(outer_it_->first)) {
+								inner_it_ = outer_it_->second.end();
+								if (inner_it_ != outer_it_->second.begin()) {
+									--inner_it_;
+									return;
+								}
+							}
+							--outer_it_;
+						}
+
+						// assert(outer_it_ == typemap_.begin())
+						if (condition_(outer_it_->first)) {
+							inner_it_ = outer_it_->second.end();
+							if (inner_it_ != outer_it_->second.begin()) {
+								--inner_it_;
+								return;
+							}
+						} else {
+							inner_it_ = outer_it_->second.begin();
+						}
+						// assert(inner_it_ == outer_it_->second.begin())
+					}
+
+
+					bool operator==(const PropertyIterator& other) const {
+						return inner_it_ == other.inner_it_ && outer_it_ == other.outer_it_;
+					}
+
+					bool operator!=(const PropertyIterator& other) const {
+						return !(*this == other);
+					}
+
+			};
+
+			class PropertyFilter {
+			public:
+				PropertyFilter(pat_prop_typemap_t& m)
+					: typemap_(m),
+					  condition_([](const std::type_index&) { return true; }),
+					  begin_(typemap_, condition_, /*is_end=*/false),
+					  end_(typemap_, condition_,   /*is_end=*/true) 
+					{}
+
+				PropertyFilter(pat_prop_typemap_t& m, std::function<bool(const std::type_index&)> condition)
+					: typemap_(m),
+					  condition_(condition),
+					  begin_(typemap_, condition_, /*is_end=*/false),
+					  end_(typemap_, condition_,   /*is_end=*/true) 
+					{}
+
+				PropertyIterator begin() const {
+					return begin_;
+				}
+
+				PropertyIterator end() const {
+					return end_;
+				}
+
+			private:
+				pat_prop_typemap_t& typemap_;
+				std::function<bool(const std::type_index&)> condition_;
+				PropertyIterator begin_;
+				PropertyIterator end_;
+				
+			};
+
 
 			/// Normal search: given a pattern, get its property if any.
 			template<class T> const T*  get(Ex::iterator, bool ignore_parent_rel=false) const;
@@ -468,18 +604,22 @@ namespace cadabra {
 		// bucket is a std::multimap taking std::type_index to pat_prop_pair_t
 		// We only care about std::type_index entries that are either castable to T 
 		// or inherit from a child
+	
+		// Outer loop runs first with wildcards = false, second (if needed) with wildcards = true
+		for(;;;) {
+			// Need an extra boolean to break two `for` loops below when needed
+			bool found_property = false;
+			for (const auto& entry : bucket) {
+				// entry.second contains all pat_prop_pairs of the same property type
+				// so we can quickly shortcut some things right now.
 
-		bool found_property = false;
-		
-		for (const auto& entry : bucket) {
-			// entry.second contains all pat_prop_pairs of the same property type
-			// So we can quickly shortcut some things right now.
-
-			// Is entry castable to T?
-			bool T_castable = is_castable(typeid(T), entry.first);
-			inherits = inherits || is_castable(typeid(PropertyInherit), entry.first) || is_castable(typeid(Inherit<T>, entry.first));
-			
-			if (T_castable) {
+				// Is entry castable to T?
+				bool T_castable = is_castable(typeid(T), entry.first);
+				// Is an interit possible?
+				inherits = inherits || is_castable(typeid(PropertyInherit), entry.first) || is_castable(typeid(Inherit<T>, entry.first));
+				
+				if (!T_castable) continue;
+				// Only enter this loop if castable to T, so we don't waste time
 				for (const auto& pat_prop_pair : entry.second) {
 					if(wildcards==pat_prop_pair.first->children_wildcard()) {
 						ret.first=dynamic_cast<const T *>(pat_prop_pair.second);
@@ -499,49 +639,19 @@ namespace cadabra {
 						ret.first=0;
 						}
 					}
+				// break out to wildcard loop
+				if (found_property)
+					break;
 				}
-			if (found_property)
-				break;
-			}
-
-		// First deal with ones that are directly castable to T
-		// FIXME: Add a cache for this
-
-
-
-		for(;;) {
-			property_map_t::const_iterator walk=pit.first;
-			while(walk!=pit.second) {
-				if(wildcards==(*walk).second.first->children_wildcard()) {
-					// First check property type; a dynamic cast is much faster than a pattern match.
-					ret.first=dynamic_cast<const T *>((*walk).second.second);
-					if(ret.first) {
-						if((*walk).second.first->match_ext(*this, it, comp, ignore_parent_rel, ignore_properties)) {
-							ret.second=(*walk).second.first;
-							if(!check_label(ret.first, label)) 
-								ret.first=0;
-							else {
-								if(doserial) 
-									serialnum=serial_number( (*walk).second.second, (*walk).second.first );
-								break;
-								}
-							}
-						}
-					ret.first=0;
-					if(dynamic_cast<const PropertyInherit *>((*walk).second.second))
-						inherits=true;
-					else if(dynamic_cast<const Inherit<T> *>((*walk).second.second))
-						inherits=true;
-					}
-				++walk;
-				}
+			
+			// Possible repeat loop for wildcard
 			if(!wildcards && !ret.first) {
 				//			std::cerr << "not yet found, switching to wildcards" << std::endl;
 				wildcards=true;
 				}
 			else break;
 			}
-
+		
 		// Do not walk down the tree if the property cannot be passed up the tree.
 		// FIXME: see issue/259.
 		if(std::is_same<T, LaTeXForm>::value)
@@ -594,9 +704,11 @@ namespace cadabra {
 		bool found=false;
 
 		bool inherits1=false, inherits2=false;
+
 		std::pair<property_map_t::const_iterator, property_map_t::const_iterator> pit1=props.equal_range(it1->name_only());
 		std::pair<property_map_t::const_iterator, property_map_t::const_iterator> pit2=props.equal_range(it2->name_only());
 
+		// walk1 walks the properties matching it1's name
 		property_map_t::const_iterator walk1=pit1.first;
 		while(walk1!=pit1.second) {
 			if((*walk1).second.first->match(*this, it1, ignore_parent_rel)) { // match for object 1 found

--- a/core/algorithms/rename_dummies.cc
+++ b/core/algorithms/rename_dummies.cc
@@ -84,16 +84,20 @@ Algorithm::result_t rename_dummies::apply(iterator& st)
 	// with this name.
 	const Indices *ind2=0;
 	if(dset2!="") {
-		auto f2=kernel.properties.pats.begin();
-		while(f2!=kernel.properties.pats.end()) {
-			ind2 = dynamic_cast<const Indices *>(f2->first);
-			if(ind2) {
-				if(ind2->set_name==dset2)
-					break;
-				else ind2=0;
+		auto pats_it = kernel.properties.pats_dict.find(typeid(Indices));
+		if (pats_it != kernel.properties.pats_dict.end()) {
+			auto pats = pats_it->second;
+			auto f2=pats.begin();
+			while(f2!=pats.end()) {
+				ind2 = dynamic_cast<const Indices *>(f2->first);
+				if(ind2) {
+					if(ind2->set_name==dset2)
+						break;
+					else ind2=0;
+					}
+				++f2;
 				}
-			++f2;
-			}
+		}
 		if(ind2==0)
 			throw ConsistencyException("No index set with name `"+dset2+"' known.");
 		}

--- a/core/algorithms/rename_dummies.cc
+++ b/core/algorithms/rename_dummies.cc
@@ -84,20 +84,17 @@ Algorithm::result_t rename_dummies::apply(iterator& st)
 	// with this name.
 	const Indices *ind2=0;
 	if(dset2!="") {
-		auto pats_it = kernel.properties.pats_dict.find(typeid(Indices));
-		if (pats_it != kernel.properties.pats_dict.end()) {
-			auto pats = pats_it->second;
-			auto f2=pats.begin();
-			while(f2!=pats.end()) {
-				ind2 = dynamic_cast<const Indices *>(f2->first);
-				if(ind2) {
-					if(ind2->set_name==dset2)
-						break;
-					else ind2=0;
-					}
-				++f2;
+		// FIXME: We assume only Indices type is castable to Indices.
+		auto f2 = kernel.properties.begin(typeid(Indices));
+		while(f2!=kernel.properties.end()) {
+			ind2 = dynamic_cast<const Indices *>(f2->first);
+			if(ind2) {
+				if(ind2->set_name==dset2)
+					break;
+				else ind2=0;
 				}
-		}
+			++f2;
+			}
 		if(ind2==0)
 			throw ConsistencyException("No index set with name `"+dset2+"' known.");
 		}

--- a/core/cadabra2_defaults.py.in
+++ b/core/cadabra2_defaults.py.in
@@ -550,6 +550,7 @@ class Console(object):
         """
         def log(self, *objs):
             """Sends a string representation of objs to the console"""
+            cell_id = 0
             if server.architecture() == "terminal":
                 print(*objs)
             elif server.architecture() == "client-server":
@@ -557,10 +558,12 @@ class Console(object):
 
         def clear(self):
             """Clears the output of the console window"""
+            cell_id = 0
             if server.architecture() == "client-server":
                 server.send("", "csl_clear", 0, cell_id, False)
 
         def warn(self, msg):
+            cell_id = 0
             if server.architecture() == "terminal":
                 print("Warning: " + msg)
             elif server.architecture() == "client-server":

--- a/core/properties/CommutingBehaviour.cc
+++ b/core/properties/CommutingBehaviour.cc
@@ -3,7 +3,7 @@
 
 using namespace cadabra;
 
-property::match_t CommutingBehaviour::equals(const property *) const
+list_property::match_t CommutingBehaviour::equals(const property *) const
 	{
 	return no_match; // you can have as many of these as you like
 	}

--- a/core/properties/Indices.cc
+++ b/core/properties/Indices.cc
@@ -20,7 +20,7 @@ std::string Indices::name() const
 	return "Indices";
 	}
 
-property::match_t Indices::equals(const property *other) const
+list_property::match_t Indices::equals(const property *other) const
 	{
 	const Indices *cast_other = dynamic_cast<const Indices *>(other);
 	if(cast_other) {
@@ -32,7 +32,7 @@ property::match_t Indices::equals(const property *other) const
 			}
 		return no_match;
 		}
-	return property::equals(other);
+	return list_property::equals(other);
 	}
 
 bool Indices::parse(Kernel& kernel, std::shared_ptr<Ex> ex, keyval_t& keyvals)

--- a/core/properties/SortOrder.cc
+++ b/core/properties/SortOrder.cc
@@ -3,7 +3,7 @@
 
 using namespace cadabra;
 
-property::match_t SortOrder::equals(const property *) const
+list_property::match_t SortOrder::equals(const property *) const
 	{
 	return no_match; // you can have as many of these as you like
 	}

--- a/core/pythoncdb/py_ex.cc
+++ b/core/pythoncdb/py_ex.cc
@@ -715,6 +715,7 @@ namespace cadabra {
 		.def("state", &Ex::state)
 		.def("reset", &Ex::reset_state)
 		.def("copy", [](const Ex& ex) { return std::make_shared<Ex>(ex); })
+		.def("size", [](const Ex& ex) { return ex.size();})
 		.def("changed", &Ex::changed_state)
 		.def("cleanup", &Ex_cleanup)
 		.def("__array__", [](Ex& ex) {

--- a/core/pythoncdb/py_properties.cc
+++ b/core/pythoncdb/py_properties.cc
@@ -284,6 +284,7 @@ namespace cadabra {
 		pybind11::list ret;
 		std::string res;
 		bool multi = false;
+		/*
 		for (auto it = props.pats.begin(); it != props.pats.end(); ++it) {
 			if (it->first->hidden()) continue;
 			
@@ -324,14 +325,15 @@ namespace cadabra {
 				res += ", ";
 				}
 			}
-		
+		*/
 		return ret;
 		}
 
 	std::vector<Ex> indices_get_all(const Indices* indices, bool include_wildcards)
 	{
 		auto kernel = get_kernel_from_scope();
-		auto its = kernel->properties.pats.equal_range(indices);
+		// auto its = kernel->properties.pats.equal_range(indices);
+		auto its = kernel->properties.pats_dict[typeid(*indices)].equal_range(indices);
 
 		std::vector<Ex> res;
 		for (auto it = its.first; it != its.second; ++it) {

--- a/core/pythoncdb/py_properties.hh
+++ b/core/pythoncdb/py_properties.hh
@@ -38,15 +38,22 @@ namespace cadabra {
 		// We keep a pointer to the C++ property, so it is possible to
 		// query properties using the Python interface. However, this C++
 		// object is owned by the C++ kernel and does not get destroyed
-		// when the Python object goes out of scope.
-		const property* prop;
+		// when the Python object goes out of scope. Member functions
+		// should always call validate(), which sets prop = nullptr if invalid.
+		mutable const property* prop;
 
-		std::vector<const pattern*> pats;
-		
 		// We also keep a shared pointer to the expression for which we
 		// have defined this property, so that we can print sensible
 		// information.
-		Ex_ptr for_obj;
+		mutable Ex_ptr for_obj;
+
+		/// Validate the property and return the associated patterns.
+		/// If the property is invalid, prop is set to nullptr.
+		void validate() const;
+
+		// FIXME: The above is a mess because we now call validate() everywhere.
+		// None of these are actually const, because prop, for_obj above are
+		// mutable. It would make more sense to just eliminate the const everywhere.
 	};
 
 

--- a/core/pythoncdb/py_properties.hh
+++ b/core/pythoncdb/py_properties.hh
@@ -41,6 +41,8 @@ namespace cadabra {
 		// when the Python object goes out of scope.
 		const property* prop;
 
+		std::vector<const pattern*> pats;
+		
 		// We also keep a shared pointer to the expression for which we
 		// have defined this property, so that we can print sensible
 		// information.
@@ -78,6 +80,10 @@ namespace cadabra {
 			// Return type is not the same as BoundPropertyBase, but this is ok
 			// by the standard as cpp_type* is convertible to property*
 			const cpp_type* get_prop() const;
+
+			/// Delete the entire property from the kernel
+			void remove_from_kernel();
+
 
 		};
 


### PR DESCRIPTION
This is a rewriting of the internal storage of the Properties class to organize properties in a more hierarchical way. This allows get<> routines to run faster, which is important when there are hundreds of properties (for example in an intricate supergravity computation with many fields / tensors). Which combined with the comparator modifications (submitted in a separate pull request), I find ~5x speedup on complicated expressions.

The basic idea is to group properties by their type, so that e.g. Indices properties all sit together. These are organized in
```
typedef std::multimap<const property *, pattern *>				propmap_t;
typedef std::map<std::type_index, propmap_t>				    typemap_t;
typedef std::map<nset_t::iterator, typemap_t, nset_it_less>		namemap_t;

typemap_t  pats_dict;
namemap_t  props_dict;
```
To eliminate some redundancy, I organized properties and patterns so that they always fundamentally sit in a propmap_t multimap, which itself sits inside a typemap_t.

The master typemap_t is the pats_dict, which is the analogue of the old pats.
To provide similar functionality as the old props, I introduced namemap_t, which maps names to typemaps. So a given prop/pat pair lives both in pats_dict and in props_dict.

(I swapped the props/pats order in props_dict relative to props because the above ends up being faster. Possibly this would be changed if patterns eventually become unique objects, i.e. a single pattern object can have multiple properties attached to it.)

To hide the internal storage from other classes, I introduce an `iterator` class and associated `begin()` and `end()` methods in `Properties`.

I also added functionality in Python to exhibit Property objects, with convenient erase() methods attached to them. The current display form of these could use some work.

Some comments:
1) I had to change the return values of Properties::master_insert and Kernel::inject_property, because of the possibility of a list_property being discarded in favor of an existing list_property. (The Python caller needs to know what the final property is.)
2) Since match_t only is used with list_property, I moved it from property to list_propery. Maybe this was wrong?