### PR TITLE
Potential Vulnerability in Cloned Code 

### DIFF
--- a/frontend/common/lodepng.cc
+++ b/frontend/common/lodepng.cc
@@ -809,7 +809,10 @@ static unsigned HuffmanTree_makeFromFrequencies(HuffmanTree* tree, const unsigne
 	while(!frequencies[numcodes - 1] && numcodes > mincodes) numcodes--; /*trim zeroes*/
 	tree->maxbitlen = maxbitlen;
 	tree->numcodes = (unsigned)numcodes; /*number of symbols*/
-	tree->lengths = (unsigned*)lodepng_realloc(tree->lengths, numcodes * sizeof(unsigned));
+	lengths = (unsigned*)lodepng_realloc(tree->lengths, numcodes * sizeof(unsigned));
+	if (!lengths)
+		lodepng_free(tree->lengths);
+	tree->lengths = lengths;
 	if(!tree->lengths) return 83; /*alloc fail*/
 	/*initialize all lengths to 0*/
 	memset(tree->lengths, 0, numcodes * sizeof(unsigned));


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in frontend/common/lodepng.cc which was cloned from FreeRDP/FreeRDP but did not receive the security patch applied. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2019-17178.

### Proposed Fix
Apply the same patch as the one in FreeRDP/FreeRDP to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2019-17178
https://github.com/FreeRDP/FreeRDP/commit/9fee4ae076b1ec97b97efb79ece08d1dab4df29a